### PR TITLE
upgrade to 0.7.1 and remove ambient-react dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3430,29 +3430,6 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
-    "ambient-react": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ambient-react/-/ambient-react-0.0.4.tgz",
-      "integrity": "sha512-W6ULj/4nqkl2Sv7xzJAucQoVF4sC/jrwgNRJ2xjkzgw7umO7FzwBkaXzakxfQZVw75uAUHPGJv/uRyZbeCYFzQ==",
-      "requires": {
-        "@types/debug": "^4.1.5",
-        "debug": "^4.1.1"
-      }
-    },
-    "ambient-stack": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ambient-stack/-/ambient-stack-0.0.2.tgz",
-      "integrity": "sha512-37FENjFIC2+xSw/Nm49zRVLG0MpEItt5Et9JnVu0SKRH0Bl1Hn5JfWRGq+xNabS/S9JavBdm4DhwiVvNwwQLbA==",
-      "requires": {
-        "@types/debug": "^4.1.5",
-        "automerge": "^0.12.1",
-        "debug": "^4.1.1",
-        "ipfs-pubsub-peer-monitor": "0.0.9",
-        "ipld-dag-cbor": "^0.15.1",
-        "is-node": "^1.0.2",
-        "tupelo-wasm-sdk": "^0.6.0-rc8"
-      }
-    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -3776,24 +3753,6 @@
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
       "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
       "dev": true
-    },
-    "automerge": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/automerge/-/automerge-0.12.1.tgz",
-      "integrity": "sha512-7JOiRk4b6EP/Uj0AjmZTeYICXJmBRHFkL0U3mlTNXuDlUr3c4v/Wb8v0RXiX4UuVgGjkovcjOdiBMkVmzdu2KQ==",
-      "requires": {
-        "immutable": "^3.8.2",
-        "transit-immutable-js": "^0.7.0",
-        "transit-js": "^0.8.861",
-        "uuid": "3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
-      }
     },
     "autoprefixer": {
       "version": "9.7.5",
@@ -4342,9 +4301,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -5991,9 +5950,9 @@
           }
         },
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -6488,9 +6447,9 @@
           }
         },
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -8861,11 +8820,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
       "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg=="
     },
-    "immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
-    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -9139,9 +9093,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -9185,14 +9139,6 @@
       "integrity": "sha512-cSITuhI8Bizrmks8rC6SmFcSbtUf9bIUPbpHetwb7T3raSseODx80Wy51JKXFkMyLAuWYHOfDie0J/kf5csGKw==",
       "requires": {
         "streaming-iterables": "^4.1.0"
-      }
-    },
-    "ipfs-pubsub-peer-monitor": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/ipfs-pubsub-peer-monitor/-/ipfs-pubsub-peer-monitor-0.0.9.tgz",
-      "integrity": "sha512-EJpfNzM9HnS95qnoi0WajNT3i8AoLIkItSdQabNfopuiL/8Ky81MRy17S1wCIRrZEq2EpogG2DfZMJdvcp2I8g==",
-      "requires": {
-        "p-forever": "^1.0.1"
       }
     },
     "ipfs-repo": {
@@ -9409,11 +9355,11 @@
       }
     },
     "ipld": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.25.3.tgz",
-      "integrity": "sha512-DuPTlfAN9Mq/6lN75R7XhEKEg0VHKaHmaKDxKO4atLIMxAAIDwi5pki8TyN81J1tI84uIIUaKuwhwlGGLIyesQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.25.5.tgz",
+      "integrity": "sha512-9t5qh/ROQyj2Denl4KbOd3SmNLTGvh33ZYbt5P8Jury8EdDoZhBvknFq4maK6GZMjEeAiXphMGg/YaKTrim5Ew==",
       "requires": {
-        "cids": "~0.7.1",
+        "cids": "~0.8.0",
         "ipfs-block": "~0.8.1",
         "ipld-dag-cbor": "~0.15.0",
         "ipld-dag-pb": "~0.18.1",
@@ -9423,6 +9369,27 @@
         "typical": "^6.0.0"
       },
       "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "cids": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.0.tgz",
+          "integrity": "sha512-HdKURxtSOnww3H28CJU2TauIklEBsOn+ouGl2EOnSfVCVkH6+sWTj7to2D/BmuWvwzEy2+ZIKdcIwsXHJBQVew==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "multibase": "~0.7.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "~0.4.17"
+          }
+        },
         "is-plain-obj": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -9434,6 +9401,15 @@
           "integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
           "requires": {
             "is-plain-obj": "^2.0.0"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
           }
         }
       }
@@ -9475,25 +9451,46 @@
       }
     },
     "ipld-dag-pb": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.3.tgz",
-      "integrity": "sha512-lE/7m5DesBqJCCIom/ohJmQViaMOKWBleB0u3yjWGJoWxqhzoQAFL0tLRNFYardUnVvqxgP+tpvoAJMGaFNNOA==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.4.tgz",
+      "integrity": "sha512-T7Fa6xDGtWqRE3uE3bU0eflKATkZrBuh7LwFByCdz0lUpES6aMRDoUdIjlOxWAvEN01oUeT7jeeX/ZWINsI1gw==",
       "requires": {
-        "cids": "~0.7.3",
+        "buffer": "^5.6.0",
+        "cids": "~0.8.0",
         "class-is": "^1.1.0",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0",
-        "protons": "^1.1.0",
-        "stable": "~0.1.8"
+        "multicodec": "^1.0.1",
+        "multihashing-async": "~0.8.1",
+        "protons": "^1.0.2"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
+          }
+        },
+        "cids": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.0.tgz",
+          "integrity": "sha512-HdKURxtSOnww3H28CJU2TauIklEBsOn+ouGl2EOnSfVCVkH6+sWTj7to2D/BmuWvwzEy2+ZIKdcIwsXHJBQVew==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "multibase": "~0.7.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "~0.4.17"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
           }
         },
         "multihashing-async": {
@@ -9507,17 +9504,6 @@
             "js-sha3": "~0.8.0",
             "multihashes": "~0.4.15",
             "murmurhash3js-revisited": "^3.0.0"
-          }
-        },
-        "protons": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-1.1.0.tgz",
-          "integrity": "sha512-rxf3et88VGRJkXIcDK1nemQM9OpnKsRVuZW+vkJLRmytA6530hQ+k/r2DpclNJCYF+xUl2MXsvRsK+MJgcbfEg==",
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "safe-buffer": "^5.1.1",
-            "signed-varint": "^2.0.1",
-            "varint": "^5.0.0"
           }
         }
       }
@@ -9533,9 +9519,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -9713,11 +9699,6 @@
       "requires": {
         "ip-regex": "^2.0.0"
       }
-    },
-    "is-node": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-node/-/is-node-1.0.2.tgz",
-      "integrity": "sha1-19ACdF733ru3R36YiVarCk/MtlM="
     },
     "is-number": {
       "version": "3.0.0",
@@ -10002,9 +9983,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -11460,9 +11441,9 @@
           }
         },
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -11664,9 +11645,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -11729,9 +11710,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -11903,13 +11884,13 @@
       }
     },
     "libp2p-interfaces": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.2.7.tgz",
-      "integrity": "sha512-CXqc8vYLoJl3riEikXTBjr2xUw8nw2uATax3HazUWMBkvGPf5ONwf+A4LDZSKVuwOWWNMWKbJ1PrD2mGRcRKjw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.2.8.tgz",
+      "integrity": "sha512-Uzjlzbjk7Bx9giSU2z3qbQv/N8iV9ARL7GV5g9UNCXEYV+lPx0CUX8egnUlxf7/EMjUTz1PsSsf8C7nOZDbVJQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "abortable-iterator": "^3.0.0",
-        "buffer": "^5.5.0",
+        "buffer": "^5.6.0",
         "chai": "^4.2.0",
         "chai-checkmark": "^1.0.1",
         "class-is": "^1.1.0",
@@ -11920,12 +11901,12 @@
         "it-pair": "^1.0.0",
         "it-pipe": "^1.0.1",
         "libp2p-tcp": "^0.14.1",
-        "multiaddr": "^7.1.0",
-        "p-limit": "^2.2.2",
+        "multiaddr": "^7.4.3",
+        "p-limit": "^2.3.0",
         "p-wait-for": "^3.1.0",
-        "peer-id": "^0.13.3",
+        "peer-id": "^0.13.11",
         "peer-info": "^0.17.0",
-        "sinon": "^9.0.0",
+        "sinon": "^9.0.2",
         "streaming-iterables": "^4.1.0"
       },
       "dependencies": {
@@ -11949,9 +11930,9 @@
           }
         },
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -12054,6 +12035,14 @@
             "path-to-regexp": "^1.7.0"
           }
         },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
         "path-to-regexp": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -12063,14 +12052,15 @@
           }
         },
         "peer-id": {
-          "version": "0.13.11",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.11.tgz",
-          "integrity": "sha512-CWDPr4ppKslARSe1qfMlGjTiDqL4Hl25Qyfq43PEPAeRD2meI8B2HfxO0NMMB8BUhNvNGPeDAwhLptyB9jVwkw==",
+          "version": "0.13.12",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.12.tgz",
+          "integrity": "sha512-kiXu62BdJNeOzqpasMiauTFlDsQmevGWftHrMlUA68FMKWeMAtHFJTDGzaMXwPyH3l1MJM+SYb3APxNLGeZP6A==",
           "requires": {
             "buffer": "^5.5.0",
             "cids": "^0.8.0",
             "class-is": "^1.1.0",
             "libp2p-crypto": "~0.17.3",
+            "minimist": "^1.2.5",
             "multihashes": "~0.4.15",
             "protons": "^1.0.2"
           }
@@ -12275,11 +12265,10 @@
       }
     },
     "libp2p-pubsub": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.4.3.tgz",
-      "integrity": "sha512-rqNxvD8p7vK+7E/GEcDquWqPDoCbwc4w7s6RLSextR/2oEHY72CFcsSQmajyLYRj1I9jZfBnrV+eB+upMoZ4Pw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.4.4.tgz",
+      "integrity": "sha512-/nFEWjaeKhDLDgXpoqZa1HivvHAQH6RCX9T+VTzQO2aUVoHWOFnrXqBeu5ffjD2DSyyaKtRs1qsLjPVsk3p2zw==",
       "requires": {
-        "bs58": "^4.0.1",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
         "it-length-prefixed": "^3.0.0",
@@ -12287,7 +12276,28 @@
         "it-pushable": "^1.3.2",
         "libp2p-crypto": "~0.17.0",
         "libp2p-interfaces": "^0.2.3",
+        "multibase": "^0.7.0",
         "protons": "^1.0.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        }
       }
     },
     "libp2p-record": {
@@ -12456,9 +12466,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -13710,9 +13720,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -13865,9 +13875,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -14557,11 +14567,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "p-forever": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/p-forever/-/p-forever-1.0.1.tgz",
-      "integrity": "sha512-9IVAxJdPk88BFMvPjzE+WTZLmAt/FBa47mYY49E2elBki4yJJmQ57XHu3o3Dm1GMde+Xf2d+PzElJIogAPwkug=="
     },
     "p-is-promise": {
       "version": "2.1.0",
@@ -16190,9 +16195,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.8.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
-      "integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
+      "integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -16204,15 +16209,15 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
         "long": "^4.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
-          "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ=="
+          "version": "13.13.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
+          "integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A=="
         }
       }
     },
@@ -16233,9 +16238,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -19144,16 +19149,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "transit-immutable-js": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/transit-immutable-js/-/transit-immutable-js-0.7.0.tgz",
-      "integrity": "sha1-mT4lCJtjEf9AIUD1VidtbSUwBdk="
-    },
-    "transit-js": {
-      "version": "0.8.861",
-      "resolved": "https://registry.npmjs.org/transit-js/-/transit-js-0.8.861.tgz",
-      "integrity": "sha512-4O9OrYPZw6C0M5gMTvaeOp+xYz6EF79JsyxIvqXHlt+pisSrioJWFOE80N8aCPoJLcNaXF442RZrVtdmd4wkDQ=="
-    },
     "ts-invariant": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
@@ -19226,9 +19221,9 @@
       "integrity": "sha512-h7VBb4Un8BX9/9bYfyeZcMS1vh+OcqPgGBw4UJsdi0LFc1F5lenTT92MueGuZgBYHNDnUTtxZDToLL3eH05jQA=="
     },
     "tupelo-wasm-sdk": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/tupelo-wasm-sdk/-/tupelo-wasm-sdk-0.6.3.tgz",
-      "integrity": "sha512-+ZrORSBNHs6FLdNqs7StQ3lvCR/gaCc/cHZmqjleHigIPTmVFAvbogmEDsOWSo4iYwnOafyWPXGSlBJa1xI1Jw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/tupelo-wasm-sdk/-/tupelo-wasm-sdk-0.7.1.tgz",
+      "integrity": "sha512-yKcMzCsSPIRe8Rz3sfsjChC409raJcKZrYJ8Wp4Kjwb8QxeplsMOXGUsQo6a4d0q9Nu4ZM4qfSInY9RnYe8j+A==",
       "requires": {
         "@types/debug": "^4.1.5",
         "@types/detect-node": "^2.0.0",
@@ -19284,9 +19279,9 @@
           }
         },
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "@types/react-router-dom": "^5.1.3",
     "@types/url-parse": "^1.4.3",
     "@types/uuid": "^7.0.2",
-    "ambient-react": "0.0.4",
-    "ambient-stack": "0.0.2",
     "axios": "^0.19.2",
     "emotion-theming": "^10.0.27",
     "graphql": "^15.0.0",
@@ -36,7 +34,7 @@
     "react-qrcode-logo": "^2.2.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
-    "tupelo-wasm-sdk": "^0.6.3",
+    "tupelo-wasm-sdk": "^0.7.1",
     "typescript": "^3.7.5",
     "url-parse": "^1.4.7",
     "uuid": "^7.0.2"

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -3,8 +3,7 @@ import { Box, Flex, FormControl, FormLabel, FormErrorMessage, Button, Input, Hea
 import { useForm } from "react-hook-form";
 import { Redirect, Link as RouterLink} from 'react-router-dom';
 import { useMutation,gql } from '@apollo/client';
-import { AppUser } from 'ambient-react';
-
+import {userNamespace} from '../store/index'
 
 const LOGIN_USER = gql`
     mutation LoginUser($namespace: String!, $username: String!, $password: String!) {
@@ -44,7 +43,7 @@ export function LoginPage() {
 
     async function onSubmit({username,password}:LoginFormData) {
         try {
-            await loginUser({variables: {username, password, namespace: AppUser.userNamespace?.toString()! }})
+            await loginUser({variables: {username, password, namespace: userNamespace.toString()! }})
         } catch (e) {
             setError("username", "unknown", `Could not create that user: ${e.message}`)
         }

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -3,7 +3,7 @@ import { Box, Flex, FormControl, FormLabel, FormErrorMessage, Button, Input, Hea
 import { useForm } from "react-hook-form";
 import { Redirect, Link as RouterLink } from 'react-router-dom';
 import { useMutation, gql } from '@apollo/client';
-import {AppUser} from 'ambient-react';
+import {userNamespace} from '../store/index';
 
 type RegistrationFormData = {
     username: string;
@@ -35,7 +35,7 @@ export function RegisterPage() {
             return
         }
         try {
-            await registerUser({variables: {username: username, password: password, namespace: AppUser.userNamespace?.toString()!} })
+            await registerUser({variables: {username: username, password: password, namespace: userNamespace} })
         } catch (e) {
             setError("username", "unknown", `Could not create that user: ${e.message}`)
             return

--- a/src/store/community.ts
+++ b/src/store/community.ts
@@ -1,0 +1,57 @@
+import {Community, EcdsaKey, ChainTree, setDataTransaction} from 'tupelo-wasm-sdk'
+import debug from 'debug'
+
+const log = debug("appCommunity")
+
+let _appCommunityPromise: Promise<Community>
+
+declare const Go:any;
+
+// TODO: we can use named chaintrees, but that requires an sdk change
+const devCommunityConfig = `
+id = "tupelolocal"
+BootstrapAddresses = [
+    "/ip4/127.0.0.1/tcp/50001/ws/ipfs/16Uiu2HAmVGfmbkFFe3c9tHUioE2Q8j7VYrTDAn7Q6bH7coJPvUpv",
+    "/ip4/127.0.0.1/tcp/50000/ws/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5", #bootstrap node websocket is last
+]
+[[signers]]
+VerKeyHex = "0x15796b266a7d6b7c6b29c5bf97ad376fe8457e4d56bb0612ec8703c65ca7b6bb5dca004d55f5238d7764cd100c9e9cac3c5abce902bae8a5f9c29de716a145595b071b1b7038a48b4f6f88e7664b38c02062f64b3ceb499e4cbb82361457dcd731f5b48901871e7fd56a9c91ab3e06d3f7cb27288962686d9a05e02c1482f01f"
+DestKeyHex = "0x04f6dee3f7da1da58afd6ee58ea6b858fb67664fc6e2240bb6e3a75c0e1db9bbef5f413c8604bb864513d3cf27eca60b539b048b2a08f8799570c14dfb73f3f391"
+
+[[signers]]
+VerKeyHex = "0x7be8c92c8c295ef3e97be28f469f5f94d10ee7db4d202776bee5cf55c62d508a0c3550a19342d768ff073c0798ce003646df586ef588a9e9443a0ca86a234ed15150dc98ecc3f1071649fca03426f1c8c215a90752f51faa3e2e788e1dae2e9e5cf87c1ca4239a0949a0ba6ea09c061a538372cc4230dedafae929b170ad7704"
+DestKeyHex = "0x0438b196bddb9c3ec395b8ccb07bdab44ec768c084e7141b09ac5638d47fffbd5e7b7623f499a2e714e31464a356a0e30ad7c93045b6cd9957b45e957cc15dcb99"
+
+[[signers]]
+VerKeyHex = "0x88aefad94805db01cacaf190f47bc9e40f584b5085c651da168ac4034d570b4750bf7b23803d204e483e407a5ca34ee7f7a434733346451cf3f5d26c0d11e5ac45398a03fbba2d3b0dfc21cdf14615430cea394bd9423d8527eaa82a96aa6d20655724d99770ee3488b6537d6be143b84b21ad5ee12c190048757fe453313fd2"
+DestKeyHex = "0x0468924bd1341b5cec1fed888aaf1e3caa94e7d0f13d4f4573b01b296374b9e710a58a7b40e7161c0bcf7fd41832441ca21076f3846e854c8d8c640f2469a552b1"
+`
+
+export function getAppCommunity(): Promise<Community> {
+    log("fetching app community")
+    if (_appCommunityPromise !== undefined) {
+        log("returning app community")
+        return _appCommunityPromise
+    }
+    _appCommunityPromise = new Promise(async (resolve) => {
+        let c: Community
+        switch (process.env.NODE_ENV) {
+            case "production":
+                log("using production community")
+                c = await Community.getDefault()
+                break;
+            default:
+                log("using development community and wasm at: ", Go.wasmpath)
+                c = await Community.fromNotaryGroupToml(devCommunityConfig)
+                await c.start()
+                Community.setDefault(c)
+                // in dev we want to actually do a transaction in order to make sure that Community has some state
+                const key = await EcdsaKey.generate()
+                const tree = await ChainTree.newEmptyTree(c.blockservice, key)
+                await c.playTransactions(tree, [setDataTransaction("/started", (new Date()).getDate())])
+        }
+        resolve(c)
+    })
+    return _appCommunityPromise
+}
+getAppCommunity()

--- a/src/store/identity.ts
+++ b/src/store/identity.ts
@@ -1,0 +1,199 @@
+import { debug } from "debug";
+import { ChainTree, EcdsaKey, setDataTransaction, setOwnershipTransaction, Tupelo, Community } from "tupelo-wasm-sdk";
+import { EventEmitter } from "events";
+import {getAppCommunity} from './community';
+
+const log = debug("identity")
+
+// TODO: this needs a rewrite, it was brought in from ambient-stack
+// but is way too much code for the new simpler graphql stuff
+
+/**
+ * The path within the user ChainTree where decentratweet stores the username
+ */
+export const usernamePath = "tupelo.me/username"
+
+/**
+ * Generates a public/private keypair from an *insecure* passphrase (username).
+ * The generated ChainTree will have a known name derived from the username
+ * argument. The very first thing you do with the ChainTree should be to
+ * ChangeOwner 
+ * @param username - the username
+ * @param appNamespace - a namespace to drop the users into (a user is globally unique to their username/appNamespace combination eg: tobowers/clownfahrt.de is different than tobowers/differentNamespace.whatever)
+ */
+const insecureUsernameKey = async (username: string, appNamespace:Uint8Array) => {
+    return EcdsaKey.passPhraseKey(Buffer.from(username), appNamespace)
+}
+
+/**
+ * Convert a username-password pair into a secure ecdsa key pair for owning
+ * arbitrary chaintrees.
+ */
+const securePasswordKey = async (username: string, password: string) => {
+    return EcdsaKey.passPhraseKey(Buffer.from(password), Buffer.from(username))
+}
+
+/**
+ * When given a public-private key pair, returns the did of a chaintree created
+ * by that pairing
+ */
+const didFromKey = async (key: EcdsaKey) => {
+    return await Tupelo.ecdsaPubkeyToDid(key.publicKey)
+}
+
+/**
+ * Looks up the user account chaintree for the given username, returning it if
+ * it exists.
+ */
+export const findUserAccount = async (username: string, appNamespace:Uint8Array):Promise<ChainTree|undefined> => {
+    const community = await getAppCommunity()
+
+    const insecureKey = await insecureUsernameKey(username, appNamespace)
+    const did = await didFromKey(insecureKey)
+
+    let tip
+    let tree:ChainTree|undefined = undefined
+
+    try {
+        tip = await community.getTip(did)
+    } catch (e) {
+        if (e.message.includes("not found")) {
+            // do nothing, let tip be null
+            return undefined
+        }
+    }
+
+    if (tip !== undefined) {
+        tree = new ChainTree({
+            store: community.blockservice,
+            tip: tip,
+        })
+    }
+
+    return tree
+};
+
+/**
+ * Verifies that the secure password key generated with the provided username
+ * and password matches one of the owner keys for the provided chaintree.
+ */
+export const verifyAccount = async (username: string, password: string, appNamespace:Uint8Array): Promise<[boolean, User?]> => {
+    let secureKey = await securePasswordKey(username, password)
+    let secureAddr = await secureKey.address()
+    const community = await getAppCommunity()
+
+    const tree = await findUserAccount(username, appNamespace)
+    if (tree === undefined) {
+        return [false, undefined]
+    }
+
+    let resolveResp = await tree.resolve("tree/_tupelo/authentications")
+    let auths: string[] = resolveResp.value
+    if (auths.includes(secureAddr)) {
+        tree.key = secureKey
+        const user = new User(username, tree, community)
+        await user.load()
+        return [true, user]
+    } else {
+        return [false, undefined]
+    }
+}
+
+/**
+ * Registers a username-password pair by creating a new account chaintree
+ * corresponding to the username, and transferring ownership to the secure key
+ * pair corresponding to the username-password pair.
+ *
+ * Returns a handle for the created * chaintree
+ */
+export const register = async (username: string, password: string, appNamespace:Uint8Array) => {
+    log("register")
+    const c = await getAppCommunity()
+    log('creating key')
+    const insecureKey = await insecureUsernameKey(username, appNamespace)
+    const secureKey = await securePasswordKey(username, password)
+    const secureKeyAddress = await secureKey.address()
+    const treeDid = await insecureKey.toDid()
+
+    try {
+        let tip = await c.getTip(treeDid)
+        if (tip) {
+            throw new Error("user already exists")
+        }
+    } catch(e) {
+        if (!(e.message.includes("not found"))) {
+            throw e
+        }
+        // otherwise we didn't find the user so we can proceed
+    }
+
+    log("creating user chaintree")
+    const userTree = await ChainTree.newEmptyTree(c.blockservice, insecureKey)
+
+    log("transferring ownership of user chaintree and registering tweet feed")
+    await c.playTransactions(userTree, [
+        // Set the ownership of the user chaintree to our secure key (thus
+        // owning the username)
+        setOwnershipTransaction([secureKeyAddress]),
+
+        // Cache the username inside of the chaintree for easier access later
+        setDataTransaction(usernamePath, username),
+    ])
+
+    userTree.key = secureKey
+
+    const user = new User(username, userTree, c)
+
+    return user
+}
+
+/**
+ * Find the username from the given user account ChainTree
+ */
+export const resolveUsername = async (tree: ChainTree) => {
+    log("fetching username")
+    const usernameResp = await tree.resolveData(usernamePath)
+    if (usernameResp.remainderPath.length && usernameResp.remainderPath.length > 0) {
+        return ""
+    } else {
+        return usernameResp.value
+    }
+}
+
+export class User extends EventEmitter {
+    tree: ChainTree
+    did?:string
+    community: Community
+    userName: string
+
+    //TODO: error handling
+    static async find(userName: string, appNamespace:Uint8Array, community: Community, ) {
+        const tree = await findUserAccount(userName, appNamespace)
+        if (!tree) {
+            throw new Error("no tree found")
+        }
+        return new User(userName, tree, community)
+    }
+
+    constructor(userName: string, tree: ChainTree, community: Community) {
+        super()
+        this.tree = tree
+        this.community = community
+        this.userName = userName
+    }
+
+    async load() {
+        await this.setDid()
+        return this
+    }
+
+    private async setDid():Promise<string> {
+        const did = await this.tree.id()
+        if (did === null) {
+            throw new Error("invalid did")
+        }
+        this.did = did
+        return did
+    }
+}
+

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,0 +1,156 @@
+import { useState, useEffect } from 'react'
+import {getAppCommunity} from './community'
+import { User, verifyAccount, register } from './identity';
+import { EcdsaKey, Repo } from 'tupelo-wasm-sdk';
+import debug from 'debug';
+import { EventEmitter } from 'events';
+const Key = require("interface-datastore").Key
+
+// TODO: this needs a rewrite, it was brought in from ambient-stack
+// but is way too much code for the new simpler graphql stuff
+
+const log = debug("util.user")
+
+const usernameKey = new Key("username")
+const privateKeyKey = new Key("privateKey")
+
+export class AppUser extends EventEmitter {
+    user?: User
+    userPromise?: Promise<User | undefined>
+    repo: Promise<Repo>
+
+    static userNamespace?:Buffer
+    static events = new EventEmitter()
+    private static namespaceSet = false
+
+    static setUserNamespace = (namespace:string) => {
+        log("userNamespace set to: ", namespace)
+        AppUser.userNamespace = Buffer.from(namespace)
+        AppUser.namespaceSet = true
+        AppUser.events.emit('_usernamespace_set')
+    }
+
+    static afterRegister?:(user:User)=>Promise<User>
+
+    constructor() {
+        super()
+        this.repo = new Promise(async (resolve) => {
+            const repo = new Repo("ambientUser")
+            await repo.init({})
+            await repo.open()
+            resolve(repo)
+        })
+        if (AppUser.namespaceSet) {
+            this.loadFromRepo()
+        } else {
+            AppUser.events.once('_usernamespace_set', ()=> {
+                this.loadFromRepo()
+            })
+        }
+    }
+
+    async logout() {
+        const repo = await this.repo
+        await repo.delete(usernameKey)
+        await repo.delete(privateKeyKey)
+        this.user = undefined
+        this.userPromise = undefined
+        this.emit('update')
+        return
+    }
+
+    async login(username: string, password: string): Promise<[boolean, User?]> {
+        if (!AppUser.userNamespace) {
+            throw new Error("you must call AppUser.setUserNamespace with something before login")
+        }
+        const repo = await this.repo
+        const [found, user] = await verifyAccount(username, password, AppUser.userNamespace)
+        if (found) {
+            await repo.put(usernameKey, Buffer.from(username))
+            //TODO: need to more securely store the private key here
+            await repo.put(privateKeyKey, user?.tree.key?.privateKey!)
+            this.user = user
+            this.userPromise = Promise.resolve(user!)
+            AppUser.events.emit('login', user)
+            this.emit('update')
+            return [true, user]
+        }
+        return [false, undefined]
+    }
+
+    async register(username: string, password: string): Promise<User> {
+        if (!AppUser.userNamespace) {
+            throw new Error("you must call AppUser.setUserNamespace with something before register")
+        }
+        log('registering user')
+        const repo = await this.repo
+
+        let user = await register(username, password, AppUser.userNamespace)
+        await repo.put(usernameKey, Buffer.from(username))
+        //TODO: need to more securely store the private key here
+        await repo.put(privateKeyKey, user.tree.key?.privateKey!)
+
+        if (AppUser.afterRegister) {
+            user = await AppUser.afterRegister(user)
+        }
+        this.user = user
+        this.userPromise = Promise.resolve(user)
+        AppUser.events.emit('registered', user)
+        this.emit('update')
+        log('done')
+        return user
+    }
+
+    async loadFromRepo() {
+        if (this.userPromise) {
+            return this.userPromise
+        }
+
+        this.userPromise = new Promise<User | undefined>(async (resolve) => {
+            if (!AppUser.userNamespace) {
+                throw new Error("you must call AppUser.setUserNamespace with something before loadFromRepo")
+            }
+
+            log("fetching user")
+            const repo = await this.repo
+            let username: string
+            try {
+                username = await repo.get(usernameKey)
+            } catch (e) {
+                if (e.code === "ERR_NOT_FOUND") {
+                    resolve(undefined)
+                    return // no user
+                }
+                throw e
+            }
+
+            const privateKey = await repo.get(privateKeyKey)
+
+            const c = await getAppCommunity()
+            const key = await EcdsaKey.fromBytes(privateKey)
+            let user
+            try {
+                user = await User.find(username.toString(), AppUser.userNamespace, c)
+            } catch (e) {
+                if (e.message === "no tree found") {
+                    await this.logout()
+                    resolve(undefined)
+                    return // no user
+                }
+                throw e
+            }
+            user.tree.key = key
+            await user.load()
+            resolve(user)
+        })
+        this.userPromise.then((user: User | undefined) => {
+            this.user = user
+        }).finally(() => {
+            this.emit('update')
+        })
+        return this.userPromise
+    }
+
+}
+
+export const appUser = new AppUser()


### PR DESCRIPTION
little bit of a bigger refactor than I wanted, but appears there's a small (but important) bug in the ambient-stack code which doesn't actually *start* community. Rather than modify ambient-stack and then upgrade the dep, I brought in the relevant files from there and *removed* the ambient-{stack,react} dependencies because we want to do that anyway. This is too much code for what we need here, but easier to have it all here and then pair down.