### PR TITLE
adds an app-level collection and adds trackables to them as they are created

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha",
+    "integration-test": "react-scripts test",
     "eject": "react-scripts eject",
     "cp:wasm": "cp ./node_modules/tupelo-wasm-sdk/lib/js/go/tupelo.wasm ./public/",
     "generate": "graphql-codegen --config codegen.yml"

--- a/src/store/collection.spec.ts
+++ b/src/store/collection.spec.ts
@@ -1,0 +1,73 @@
+import 'mocha';
+import {expect} from 'chai';
+import { AppCollection } from './collection';
+import { getAppCommunity } from './community';
+import { ChainTree, EcdsaKey, setDataTransaction, Tupelo } from 'tupelo-wasm-sdk';
+import { Trackable } from '../generated/graphql';
+
+const namespace = "testnamespace"
+
+describe('AppCollection', ()=> {
+    it('works with an unknown tree', async ()=> {
+        await getAppCommunity()
+        const name = `tree-${Math.random()}`
+        const collection = new AppCollection({name: name, namespace: namespace})
+
+        const trackable:Trackable = {
+            did: 'nonsense',
+            updates: {},
+        }
+
+        const proof = await collection.addTrackable(trackable)
+        expect(proof).to.not.be.undefined
+
+        expect(await collection.getTrackables()).to.include(trackable.did)
+    })
+
+    it('adds to an existing tree', async ()=> {
+        const c = await getAppCommunity()
+        const name = `tree-${Math.random()}`
+        const key = await EcdsaKey.passPhraseKey(Buffer.from(name), Buffer.from(namespace))
+        let tree = await ChainTree.newEmptyTree(c.blockservice, key)
+        await c.playTransactions(tree, [setDataTransaction('nothing', 'toseehere')])
+        const collection = new AppCollection({name: name, namespace: namespace})
+
+        const trackable:Trackable = {
+            did: 'nonsense',
+            updates: {},
+        }
+
+        const proof = await collection.addTrackable(trackable)
+        expect(proof).to.not.be.undefined
+        tree = await Tupelo.getLatest(await key.toDid())
+        const resp = await tree.resolveData(`trackables/${trackable.did}`)
+        expect(resp.value).to.be.true
+    })
+
+    it('resolves conflicts from two different collections writing', async ()=> {
+        const c = await getAppCommunity()
+        const name = `tree-${Math.random()}`
+        
+        const collection1 = new AppCollection({name: name, namespace: namespace})
+        const collection2 = new AppCollection({name: name, namespace: namespace})
+
+        const trackable1:Trackable = {
+            did: 'did:tupelo:trackable1',
+            updates: {},
+        }
+        const trackable2:Trackable = {
+            did: 'did:tupelo:trackable2',
+            updates: {},
+        }
+
+        const proof = await collection1.addTrackable(trackable1)
+        const proof2 = await collection2.addTrackable(trackable2)
+        expect(proof).to.not.be.undefined
+        expect(proof2).to.not.be.undefined
+        await collection1.updateTree()
+        await collection2.updateTree()
+        expect(await collection1.getTrackables()).to.have.members([trackable1.did, trackable2.did])
+        expect(await collection2.getTrackables()).to.have.members([trackable1.did, trackable2.did])
+    })
+
+})

--- a/src/store/collection.ts
+++ b/src/store/collection.ts
@@ -2,7 +2,6 @@ import { ChainTree, Tupelo, EcdsaKey, setDataTransaction, Community } from "tupe
 import { Trackable } from "../generated/graphql"
 import { getAppCommunity } from "./community"
 import debug from 'debug'
-import { rejects } from "assert"
 
 const log = debug("AppCollection")
 
@@ -28,7 +27,7 @@ export class AppCollection {
     }
 
     private async findOrCreateTree(): Promise<ChainTree> {
-        const c = await Community.getDefault()
+        const c = await getAppCommunity()
 
         const key = await EcdsaKey.passPhraseKey(this.name, this.namespace)
         const did = await key.toDid()

--- a/src/store/collection.ts
+++ b/src/store/collection.ts
@@ -1,0 +1,86 @@
+import { ChainTree, Tupelo, EcdsaKey, setDataTransaction, Community } from "tupelo-wasm-sdk"
+import { Trackable } from "../generated/graphql"
+import { getAppCommunity } from "./community"
+import debug from 'debug'
+import { rejects } from "assert"
+
+const log = debug("AppCollection")
+
+/**
+ * Implements the global collection used by the application.
+ */
+
+/**
+ * AppCollection is a app-level chaintree owned by a known key (anyone can write)
+ * This allows the trackables added by donators to add their donation to a list
+ * of donations which the drivers can then pick.
+ */
+export class AppCollection {
+    private name: Buffer
+    private namespace: Buffer
+    treePromise: Promise<ChainTree>
+
+
+    constructor({ name, namespace }: { name: string, namespace: string }) {
+        this.name = Buffer.from(name)
+        this.namespace = Buffer.from(namespace)
+        this.treePromise = this.findOrCreateTree()
+    }
+
+    private async findOrCreateTree(): Promise<ChainTree> {
+        const c = await Community.getDefault()
+
+        const key = await EcdsaKey.passPhraseKey(this.name, this.namespace)
+        const did = await key.toDid()
+        try {
+            const tree = await Tupelo.getLatest(did)
+            tree.key = key
+            return tree
+        } catch (err) {
+            log(err)
+            if (err.message.includes("not found")) {
+                return ChainTree.newEmptyTree(c.blockservice, key)
+            }
+            throw err
+        }
+    }
+
+    updateTree() {
+        let treeP = this.treePromise
+
+        this.treePromise = new Promise<ChainTree>(async (resolve, reject) => {
+                let tree = await treeP
+                const key = tree.key
+                try {
+                    const latestTree = await Tupelo.getLatest((await tree.id())!)
+                    tree = latestTree // doesn't get here on error
+                    tree.key = key
+                } catch(err) {
+                    // if we go to get latest and it's not found, we'll
+                    // just assume we're still at a blank tree (which is fine)
+                    // and just fall back to the original 
+                    if (!err.message.includes("not found")) {
+                        reject(err)
+                        return
+                    }
+                }
+                resolve(tree)
+        })
+        return this.treePromise
+    }
+
+    async getTrackables() {
+        const tree = await this.treePromise
+        const dids = await tree.resolveData("trackables")
+        return Object.keys(dids.value)
+    }
+
+    async addTrackable(trackable: Trackable) {
+        // TODO: this needs to retry but for now we'll assume low throughput
+        //  and just grab the latest
+        let tree = await this.updateTree()
+        
+        const c = await getAppCommunity()
+        return c.playTransactions(tree, [setDataTransaction(`trackables/${trackable.did}`, true)])
+    }
+}


### PR DESCRIPTION
This is to support

https://trello.com/c/b4iB104n/23-driver-summary and the other "big collection" style ones. 

I think we'll have to support retries too, but at least this gets us going in terms of data formats and unlocks the UI usecases.