### PR TITLE
data model changes for summary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import './store'; // for side effects only
 import { ApolloProvider, useQuery } from '@apollo/client';
 import {client} from './store/index';
 import { CURRENT_USER } from './store/queries';
+import { SummaryPage } from './pages/summary';
 
 // A wrapper for <Route> that redirects to the login
 // screen if you're not yet authenticated.
@@ -78,6 +79,9 @@ function App() {
             </Route>
             <AuthenticatedRoute path="/objects/:objectId">
               <ObjectPage />
+            </AuthenticatedRoute>
+            <AuthenticatedRoute path="/summary">
+              <SummaryPage />
             </AuthenticatedRoute>
             <AuthenticatedRoute path="/">
               <Index />

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -32,6 +32,7 @@ export type Trackable = {
   image?: Maybe<Scalars['String']>;
   updates: TrackableUpdateConnection;
   collaborators?: Maybe<TrackableCollaboratorConnection>;
+  driver?: Maybe<User>;
 };
 
 export type TrackableCollaboratorConnection = {
@@ -116,6 +117,7 @@ export type AcceptJobPayload = {
 
 export type GetTrackablesFilter = {
   owned?: Maybe<Scalars['Boolean']>;
+  ownedBy?: Maybe<Scalars['String']>;
 };
 
 export type Query = {
@@ -333,6 +335,7 @@ export type TrackableResolvers<ContextType = any, ParentType extends ResolversPa
   image?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   updates?: Resolver<ResolversTypes['TrackableUpdateConnection'], ParentType, ContextType>,
   collaborators?: Resolver<Maybe<ResolversTypes['TrackableCollaboratorConnection']>, ParentType, ContextType>,
+  driver?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -19,7 +19,10 @@ export type User = {
   username?: Maybe<Scalars['String']>;
   namespace?: Maybe<Scalars['String']>;
   loggedIn?: Maybe<Scalars['Boolean']>;
+  /** @deprecated only drivers are users now and this field used to represent a collection a user owns */
   collection?: Maybe<TrackableCollection>;
+  pendingDeliveries?: Maybe<TrackableCollection>;
+  completedDeliveries?: Maybe<TrackableCollection>;
 };
 
 export type Trackable = {
@@ -101,15 +104,35 @@ export type AddCollaboratorInput = {
   username: Scalars['String'];
 };
 
+export type AcceptJobInput = {
+  user: Scalars['ID'];
+  trackable: Scalars['ID'];
+};
+
+export type AcceptJobPayload = {
+   __typename?: 'AcceptJobPayload';
+  trackable?: Maybe<Trackable>;
+};
+
+export type GetTrackablesFilter = {
+  owned?: Maybe<Scalars['Boolean']>;
+};
+
 export type Query = {
    __typename?: 'Query';
   getTrackable?: Maybe<Trackable>;
+  getTrackables?: Maybe<TrackableCollection>;
   me?: Maybe<User>;
 };
 
 
 export type QueryGetTrackableArgs = {
   did: Scalars['ID'];
+};
+
+
+export type QueryGetTrackablesArgs = {
+  filters?: Maybe<GetTrackablesFilter>;
 };
 
 export type Mutation = {
@@ -120,6 +143,7 @@ export type Mutation = {
   createTrackable?: Maybe<CreateTrackablePayload>;
   addUpdate?: Maybe<AddUpdatePayload>;
   addCollaborator?: Maybe<AddCollaboratorPayload>;
+  acceptJob?: Maybe<AcceptJobPayload>;
 };
 
 
@@ -154,6 +178,11 @@ export type MutationAddUpdateArgs = {
 
 export type MutationAddCollaboratorArgs = {
   input: AddCollaboratorInput;
+};
+
+
+export type MutationAcceptJobArgs = {
+  input: AcceptJobInput;
 };
 
 
@@ -248,6 +277,9 @@ export type ResolversTypes = {
   AddCollaboratorPayload: ResolverTypeWrapper<AddCollaboratorPayload>,
   Int: ResolverTypeWrapper<Scalars['Int']>,
   AddCollaboratorInput: AddCollaboratorInput,
+  AcceptJobInput: AcceptJobInput,
+  AcceptJobPayload: ResolverTypeWrapper<AcceptJobPayload>,
+  GetTrackablesFilter: GetTrackablesFilter,
   Query: ResolverTypeWrapper<{}>,
   Mutation: ResolverTypeWrapper<{}>,
 };
@@ -273,6 +305,9 @@ export type ResolversParentTypes = {
   AddCollaboratorPayload: AddCollaboratorPayload,
   Int: Scalars['Int'],
   AddCollaboratorInput: AddCollaboratorInput,
+  AcceptJobInput: AcceptJobInput,
+  AcceptJobPayload: AcceptJobPayload,
+  GetTrackablesFilter: GetTrackablesFilter,
   Query: {},
   Mutation: {},
 };
@@ -287,6 +322,8 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
   namespace?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   loggedIn?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
   collection?: Resolver<Maybe<ResolversTypes['TrackableCollection']>, ParentType, ContextType>,
+  pendingDeliveries?: Resolver<Maybe<ResolversTypes['TrackableCollection']>, ParentType, ContextType>,
+  completedDeliveries?: Resolver<Maybe<ResolversTypes['TrackableCollection']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
@@ -348,8 +385,14 @@ export type AddCollaboratorPayloadResolvers<ContextType = any, ParentType extend
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
+export type AcceptJobPayloadResolvers<ContextType = any, ParentType extends ResolversParentTypes['AcceptJobPayload'] = ResolversParentTypes['AcceptJobPayload']> = {
+  trackable?: Resolver<Maybe<ResolversTypes['Trackable']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   getTrackable?: Resolver<Maybe<ResolversTypes['Trackable']>, ParentType, ContextType, RequireFields<QueryGetTrackableArgs, 'did'>>,
+  getTrackables?: Resolver<Maybe<ResolversTypes['TrackableCollection']>, ParentType, ContextType, RequireFields<QueryGetTrackablesArgs, never>>,
   me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
 };
 
@@ -360,6 +403,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   createTrackable?: Resolver<Maybe<ResolversTypes['CreateTrackablePayload']>, ParentType, ContextType, RequireFields<MutationCreateTrackableArgs, 'input'>>,
   addUpdate?: Resolver<Maybe<ResolversTypes['AddUpdatePayload']>, ParentType, ContextType, RequireFields<MutationAddUpdateArgs, 'input'>>,
   addCollaborator?: Resolver<Maybe<ResolversTypes['AddCollaboratorPayload']>, ParentType, ContextType, RequireFields<MutationAddCollaboratorArgs, 'input'>>,
+  acceptJob?: Resolver<Maybe<ResolversTypes['AcceptJobPayload']>, ParentType, ContextType, RequireFields<MutationAcceptJobArgs, 'input'>>,
 };
 
 export type Resolvers<ContextType = any> = {
@@ -374,6 +418,7 @@ export type Resolvers<ContextType = any> = {
   CreateTrackablePayload?: CreateTrackablePayloadResolvers<ContextType>,
   AddUpdatePayload?: AddUpdatePayloadResolvers<ContextType>,
   AddCollaboratorPayload?: AddCollaboratorPayloadResolvers<ContextType>,
+  AcceptJobPayload?: AcceptJobPayloadResolvers<ContextType>,
   Query?: QueryResolvers<ContextType>,
   Mutation?: MutationResolvers<ContextType>,
 };

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -67,6 +67,12 @@ export type TrackableCollection = {
   trackables?: Maybe<Array<Trackable>>;
 };
 
+export type AppCollection = {
+   __typename?: 'AppCollection';
+  did: Scalars['ID'];
+  trackables?: Maybe<Array<Trackable>>;
+};
+
 export type CreateTrackableInput = {
   name: Scalars['String'];
   image?: Maybe<Scalars['String']>;
@@ -123,18 +129,13 @@ export type GetTrackablesFilter = {
 export type Query = {
    __typename?: 'Query';
   getTrackable?: Maybe<Trackable>;
-  getTrackables?: Maybe<TrackableCollection>;
+  getTrackables?: Maybe<AppCollection>;
   me?: Maybe<User>;
 };
 
 
 export type QueryGetTrackableArgs = {
   did: Scalars['ID'];
-};
-
-
-export type QueryGetTrackablesArgs = {
-  filters?: Maybe<GetTrackablesFilter>;
 };
 
 export type Mutation = {
@@ -271,6 +272,7 @@ export type ResolversTypes = {
   TrackableUpdate: ResolverTypeWrapper<TrackableUpdate>,
   MetadataEntry: ResolverTypeWrapper<MetadataEntry>,
   TrackableCollection: ResolverTypeWrapper<TrackableCollection>,
+  AppCollection: ResolverTypeWrapper<AppCollection>,
   CreateTrackableInput: CreateTrackableInput,
   MetadataEntryInput: MetadataEntryInput,
   AddUpdateInput: AddUpdateInput,
@@ -299,6 +301,7 @@ export type ResolversParentTypes = {
   TrackableUpdate: TrackableUpdate,
   MetadataEntry: MetadataEntry,
   TrackableCollection: TrackableCollection,
+  AppCollection: AppCollection,
   CreateTrackableInput: CreateTrackableInput,
   MetadataEntryInput: MetadataEntryInput,
   AddUpdateInput: AddUpdateInput,
@@ -371,6 +374,12 @@ export type TrackableCollectionResolvers<ContextType = any, ParentType extends R
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
+export type AppCollectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['AppCollection'] = ResolversParentTypes['AppCollection']> = {
+  did?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+  trackables?: Resolver<Maybe<Array<ResolversTypes['Trackable']>>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
 export type CreateTrackablePayloadResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateTrackablePayload'] = ResolversParentTypes['CreateTrackablePayload']> = {
   collection?: Resolver<Maybe<ResolversTypes['TrackableCollection']>, ParentType, ContextType>,
   trackable?: Resolver<Maybe<ResolversTypes['Trackable']>, ParentType, ContextType>,
@@ -395,7 +404,7 @@ export type AcceptJobPayloadResolvers<ContextType = any, ParentType extends Reso
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   getTrackable?: Resolver<Maybe<ResolversTypes['Trackable']>, ParentType, ContextType, RequireFields<QueryGetTrackableArgs, 'did'>>,
-  getTrackables?: Resolver<Maybe<ResolversTypes['TrackableCollection']>, ParentType, ContextType, RequireFields<QueryGetTrackablesArgs, never>>,
+  getTrackables?: Resolver<Maybe<ResolversTypes['AppCollection']>, ParentType, ContextType>,
   me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
 };
 
@@ -418,6 +427,7 @@ export type Resolvers<ContextType = any> = {
   TrackableUpdate?: TrackableUpdateResolvers<ContextType>,
   MetadataEntry?: MetadataEntryResolvers<ContextType>,
   TrackableCollection?: TrackableCollectionResolvers<ContextType>,
+  AppCollection?: AppCollectionResolvers<ContextType>,
   CreateTrackablePayload?: CreateTrackablePayloadResolvers<ContextType>,
   AddUpdatePayload?: AddUpdatePayloadResolvers<ContextType>,
   AddCollaboratorPayload?: AddCollaboratorPayloadResolvers<ContextType>,

--- a/src/pages/object.tsx
+++ b/src/pages/object.tsx
@@ -130,7 +130,7 @@ export function CollaboratorUI({did}:{did: Scalars['ID']}) {
             },
             update: (proxy, {data: {addCollaborator}})=> {
                 const data:any = proxy.readQuery({query: GET_COLLABORATORS, variables: {did: did}})
-                console.log("update called: ", addCollaborator, " readQuery: ", data)
+                log("update called: ", addCollaborator, " readQuery: ", data)
                 // data.me.collection.trackables.push(createTrackable.trackable)
                 // TODO: this should be a deep merge
                 proxy.writeQuery({
@@ -223,7 +223,7 @@ function ObjectUpdate({ update }: { update: TrackableUpdate }) {
             metadata[key] = value
         })
     }
-    console.log("metadata: ", metadata)
+    log("metadata: ", metadata)
 
     if (metadata.image) {
         img = <Image src={getUrl(metadata.image)} />
@@ -305,7 +305,7 @@ export function ObjectPage() {
             },
             update: (proxy, {data: {addUpdate}})=> {
                 const data:any = proxy.readQuery({query: GET_TRACKABLE, variables: {did: objectId}})
-                console.log("update called: ", addUpdate, " readQuery: ", data)
+                log("update called: ", addUpdate, " readQuery: ", data)
                 // data.me.collection.trackables.push(createTrackable.trackable)
                 // TODO: this should be a deep merge
                 proxy.writeQuery({

--- a/src/pages/summary.tsx
+++ b/src/pages/summary.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import { gql, useQuery } from '@apollo/client'
+import { Box, Spinner, Heading, Image, Text, Flex} from '@chakra-ui/core'
+import { Trackable } from '../generated/graphql'
+import { useHistory } from 'react-router-dom'
+import Header from '../components/header'
+
+const SUMMARY_PAGE_QUERY = gql`
+    query SummaryPage($filters: GetTrackablesFilter) {
+        me {
+            did
+        }
+        getTrackables(filters: $filters) {
+            did
+            trackables {
+                did
+            }
+        }
+    }
+`
+
+export function SummaryPage() {
+    const { data, loading, error } = useQuery(SUMMARY_PAGE_QUERY)
+
+    if (loading) {
+        return (
+            <Box>
+                <Spinner />
+            </Box>
+        )
+    }
+
+    if (error) {
+        return (
+            <Box>
+                <Text>{error}</Text>
+            </Box>
+        )
+    }
+
+    const unowned = data.getTrackables.trackables.filter((trackable: Trackable) => {
+        return !trackable.driver
+    })
+
+    const myTrackables = data.getTrackables.trackables.filter((trackable: Trackable) => {
+        return trackable.driver === data.me.did
+    })
+
+    return (
+        <Box>
+        <Header />
+        <Flex mt={5} p={10} flexDirection="column">
+        <Box>
+            <Box>
+                Find more deliveries
+                ({unowned.length}) available
+            </Box>
+            <Heading>Your current deliveries</Heading>
+            <TrackableCollection trackables={myTrackables} />
+        </Box>
+        </Flex>
+        </Box>
+    )
+}
+
+function TrackableCollection({ trackables }: { trackables: Trackable[] }) {
+    const history = useHistory()
+
+    const trackableElements = trackables.map((trackable: Trackable) => {
+        return (
+
+            <Box p="5" ml="2" maxW="sm" borderWidth="1px" rounded="lg" overflow="hidden" key={trackable.did} onClick={() => { history.push(`/objects/${trackable.did}`) }}>
+                {/* {trackable.image &&
+                    <Image src={getUrl(trackable.image)} />
+                } */}
+                <Box
+                    mt="1"
+                    fontWeight="semibold"
+                    as="h4"
+                    lineHeight="tight"
+                    isTruncated
+                >
+                    {trackable.name}
+                </Box>
+                <Box mt="2" color="gray.600" fontSize="sm">
+                    {trackable.did}
+                </Box>
+            </Box>
+        )
+    })
+    return (
+        <>
+            {trackableElements}
+        </>
+    )
+}

--- a/src/pages/summary.tsx
+++ b/src/pages/summary.tsx
@@ -4,6 +4,9 @@ import { Box, Spinner, Heading, Image, Text, Flex, Button } from '@chakra-ui/cor
 import { Trackable, User } from '../generated/graphql'
 import { Link} from 'react-router-dom'
 import Header from '../components/header'
+import debug from 'debug'
+
+const log = debug("pages.summary")
 
 const SUMMARY_PAGE_QUERY = gql`
     query SummaryPage($filters: GetTrackablesFilter) {
@@ -45,7 +48,7 @@ export function SummaryPage() {
         )
     }
 
-    console.log("summary page data: ", data)
+    log("summary page data: ", data)
 
     const unowned = data.getTrackables.trackables.filter((trackable: Trackable) => {
         return !trackable.driver

--- a/src/store/collection.spec.ts
+++ b/src/store/collection.spec.ts
@@ -41,7 +41,7 @@ describe('AppCollection', ()=> {
         expect(proof).to.not.be.undefined
         tree = await Tupelo.getLatest(await key.toDid())
         const resp = await tree.resolveData(`trackables/${trackable.did}`)
-        expect(resp.value).to.be.true
+        expect(resp.value).to.be.false // false means 'unowned'
     })
 
     it('resolves conflicts from two different collections writing', async ()=> {
@@ -68,6 +68,25 @@ describe('AppCollection', ()=> {
         await collection2.updateTree()
         expect(await collection1.getTrackables()).to.have.members([trackable1.did, trackable2.did])
         expect(await collection2.getTrackables()).to.have.members([trackable1.did, trackable2.did])
+    })
+
+    it('can own a trackable', async ()=> {
+        await getAppCommunity()
+        const name = `tree-${Math.random()}`
+        const collection = new AppCollection({name: name, namespace: namespace})
+
+        const trackable:Trackable = {
+            did: 'nonsense',
+            updates: {},
+        }
+
+        const proof = await collection.addTrackable(trackable)
+        expect(proof).to.not.be.undefined
+
+        expect(await collection.getTrackables()).to.include(trackable.did)
+
+        await collection.ownTrackable(trackable, {did: "did:test:userDid"})
+
     })
 
 })

--- a/src/store/collection.spec.ts
+++ b/src/store/collection.spec.ts
@@ -21,7 +21,7 @@ describe('AppCollection', ()=> {
         const proof = await collection.addTrackable(trackable)
         expect(proof).to.not.be.undefined
 
-        expect(await collection.getTrackables()).to.include(trackable.did)
+        expect((await collection.getTrackables()).map((t)=> {return t.did})).to.include(trackable.did)
     })
 
     it('adds to an existing tree', async ()=> {
@@ -66,8 +66,8 @@ describe('AppCollection', ()=> {
         expect(proof2).to.not.be.undefined
         await collection1.updateTree()
         await collection2.updateTree()
-        expect(await collection1.getTrackables()).to.have.members([trackable1.did, trackable2.did])
-        expect(await collection2.getTrackables()).to.have.members([trackable1.did, trackable2.did])
+        expect((await collection1.getTrackables()).map((t)=>{return t.did})).to.have.members([trackable1.did,trackable2.did])
+        expect((await collection2.getTrackables()).map((t)=>{return t.did})).to.have.members([trackable1.did, trackable2.did])
     })
 
     it('can own a trackable', async ()=> {
@@ -83,10 +83,13 @@ describe('AppCollection', ()=> {
         const proof = await collection.addTrackable(trackable)
         expect(proof).to.not.be.undefined
 
-        expect(await collection.getTrackables()).to.include(trackable.did)
+
+
+        expect((await collection.getTrackables()).some((listTrackable)=> {
+            return listTrackable.did === trackable.did
+        })).to.be.true
 
         await collection.ownTrackable(trackable, {did: "did:test:userDid"})
-
     })
 
 })

--- a/src/store/collection.ts
+++ b/src/store/collection.ts
@@ -1,5 +1,5 @@
 import { ChainTree, Tupelo, EcdsaKey, setDataTransaction, Community } from "tupelo-wasm-sdk"
-import { Trackable } from "../generated/graphql"
+import { Trackable, User } from "../generated/graphql"
 import { getAppCommunity } from "./community"
 import debug from 'debug'
 
@@ -80,6 +80,16 @@ export class AppCollection {
         let tree = await this.updateTree()
         
         const c = await getAppCommunity()
-        return c.playTransactions(tree, [setDataTransaction(`trackables/${trackable.did}`, true)])
+        return c.playTransactions(tree, [setDataTransaction(`trackables/${trackable.did}`, false)]) // false means "unowned"
+    }
+
+    async ownTrackable(trackable: Trackable, user: User) {
+        // TODO: as in addTrackable, this needs to retry but for now we'll assume low throughput
+        //  and just grab the latest
+        let tree = await this.updateTree()
+        
+        const c = await getAppCommunity()
+        // set the trackable DID to the DID of the driver picking it up
+        return c.playTransactions(tree, [setDataTransaction(`trackables/${trackable.did}`, user.did)])
     }
 }

--- a/src/store/collection.ts
+++ b/src/store/collection.ts
@@ -68,10 +68,22 @@ export class AppCollection {
         return this.treePromise
     }
 
-    async getTrackables() {
+    async getTrackables():Promise<Trackable[]> {
         const tree = await this.treePromise
         const dids = await tree.resolveData("trackables")
-        return Object.keys(dids.value)
+        return Object.keys(dids.value).map((did:string)=> {
+            const trackable:Trackable = {
+                did: did,
+                updates: {},
+            }
+            const driver = dids.value[did]
+            if (driver) {
+                trackable.driver = {
+                    did: driver,
+                }
+            }
+            return trackable
+        })
     }
 
     async addTrackable(trackable: Trackable) {

--- a/src/store/index.spec.ts
+++ b/src/store/index.spec.ts
@@ -30,8 +30,52 @@ describe('resolvers', () => {
         expect(resp.error).to.be.undefined
     })
 
-    it('queries trackables', async () => {
+    it('creates trackables', async ()=> {
+        const CREATE_TRACKABLE = gql`
+            mutation CreateTrackable($input: CreateTrackableInput!) {
+                createTrackable(input: $input) {
+                    collection {
+                        did
+                    }
+                    trackable {
+                        did
+                        name
+                        image
+                    }
+                }
+            }
+        `
 
+                // it adds to the app collection
+            const appTrackableQuery = gql`
+               {
+                    getTrackables {
+                        did
+                        trackables {
+                            did
+                            driver
+                        }
+                    }
+                }
+            `
+
+        const mutateResp = await client.mutate({
+            mutation: CREATE_TRACKABLE,
+            variables: {input: {name: "test1"}},
+            refetchQueries: [{query: appTrackableQuery}]
+        })
+        expect(mutateResp.error).to.be.undefined
+        expect(mutateResp.data.createTrackable.trackable.name).to.equal("test1")
+
+
+        const queryResp = await client.query({
+            query: appTrackableQuery,
+        })
+        expect(queryResp.errors).to.be.undefined
+        expect(queryResp.data.getTrackables.trackables.length).to.be.greaterThan(0)
+    })
+
+    it('queries trackables', async () => {
         const query = gql`
             query GetTrackables($filters: GetTrackablesFilter) {
                 getTrackables(filters: $filters) {

--- a/src/store/index.spec.ts
+++ b/src/store/index.spec.ts
@@ -1,0 +1,90 @@
+import 'mocha'
+import { expect } from 'chai'
+import { client, userNamespace } from './index'
+import { gql } from '@apollo/client'
+import { CURRENT_USER } from './queries'
+
+
+// right now the tests are stateful (state sticks around between tests)
+// so this is really just a "does it actually run" kind of test rather
+// than really asserting anything useful.
+describe('resolvers', () => {
+    const userEmail = `tester-${Math.random()}@testhead.eth`
+    const password = 'password' // I like to live dangerously
+
+    before(async ()=> {
+        const registerMutation = gql`
+            mutation RegisterUser($namespace: String!, $username: String!, $password: String!) {
+                register(namespace: $namespace, username: $username, password: $password) {
+                    did
+                    username
+                    loggedIn
+                }
+            }
+        `
+
+        const resp = await client.mutate({
+            mutation: registerMutation,
+            variables: {namespace: userNamespace, username: userEmail, password: password}
+        })
+        expect(resp.error).to.be.undefined
+    })
+
+    it('queries trackables', async () => {
+
+        const query = gql`
+            query GetTrackables($filters: GetTrackablesFilter) {
+                getTrackables(filters: $filters) {
+                    did
+                    trackables {
+                        did
+                    }
+                }
+            }
+        `
+        const resp = await client.query({
+            query: query,
+            variables: {filters: {owned:false}}
+        })
+
+        expect(resp.data.getTrackables.trackables).to.be.an("Array")
+    })
+
+    it('can accept jobs', async ()=> {
+        const acceptMutation = gql`
+            mutation AcceptJob($input: AcceptJobInput) {
+                acceptJob(input: $input) {
+                    trackable {
+                        did
+                    }
+                }
+            }
+        `
+
+        const createTrackableMutation = gql`
+        mutation CreateTrackable($input: CreateTrackableInput!) {
+            createTrackable(input: $input) {
+                trackable {
+                    did
+                }
+            }
+        }
+    `
+
+        const currUserResp = await client.query({query: CURRENT_USER})
+        expect(currUserResp.errors).to.be.undefined
+
+        const createTrackableResp = await client.mutate({
+            mutation: createTrackableMutation,
+            variables: {input: {name: "testtrackable"}}
+        }) 
+        expect(createTrackableResp.error).to.be.undefined
+
+        const resp = await client.mutate({
+            mutation: acceptMutation,
+            variables: {input: {user: currUserResp.data.me.did, trackable: createTrackableResp.data.createTrackable.trackable.did}}
+        })
+
+        expect(resp.error).to.be.undefined
+    })
+})

--- a/src/store/index.spec.ts
+++ b/src/store/index.spec.ts
@@ -43,8 +43,7 @@ describe('resolvers', () => {
             }
         `
         const resp = await client.query({
-            query: query,
-            variables: {filters: {owned:false}}
+            query: query
         })
 
         expect(resp.data.getTrackables.trackables).to.be.an("Array")

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -148,7 +148,7 @@ const resolvers: Resolvers = {
                 // updates is a map of timestamp to TrackableUpdate
                 let edges = await Promise.all(Object.keys(updates.value).map(async (timestamp)=> {
                     let update = (await tree.resolveData(`updates/${timestamp}`)).value
-                    console.log("resolved update: ", update)
+                    log("resolved update: ", update)
                     update.did = `${did}-${timestamp}`
                     return update
                 }))

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -179,15 +179,9 @@ const resolvers: Resolvers = {
 
     Query: {
         getTrackables: async(_root, {filters}:QueryGetTrackablesArgs, _ctx:TrackerContext) => {
-            let dids = await appCollection.getTrackables()
             return {
                 did: await (await appCollection.treePromise).id()!,
-                trackables: dids.map((did:string):Trackable => {
-                    return {
-                        did: did,
-                        updates: {},
-                    }
-                })
+                trackables: await appCollection.getTrackables(),
             } as TrackableCollection
         },
         getTrackable: async (_root, {did}:QueryGetTrackableArgs ,_ctx:TrackerContext) => {

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -49,6 +49,13 @@ type TrackableCollection {
     trackables: [Trackable!]
 }
 
+# AppCollection is kept as a separate type from TrackableCollection
+# because of how they are updated
+type AppCollection {
+    did: ID!
+    trackables: [Trackable!]
+}
+
 input CreateTrackableInput {
     name: String!
     image: String
@@ -100,7 +107,7 @@ input GetTrackablesFilter {
 
 type Query {
     getTrackable(did: ID!):Trackable
-    getTrackables(filters: GetTrackablesFilter):TrackableCollection
+    getTrackables:AppCollection
     me: User
 }
 

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -19,6 +19,7 @@ type Trackable {
     image: String #skynet URL for now
     updates: TrackableUpdateConnection!
     collaborators: TrackableCollaboratorConnection
+    driver: User # this is only available on trackables that are part of a collection
 }
 
 type TrackableCollaboratorConnection {
@@ -94,6 +95,7 @@ type AcceptJobPayload {
 
 input GetTrackablesFilter {
     owned: Boolean
+    ownedBy: String
 }
 
 type Query {

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -8,7 +8,9 @@ type User {
     username: String
     namespace: String
     loggedIn: Boolean
-    collection: TrackableCollection
+    collection: TrackableCollection @deprecated(reason: "only drivers are users now and this field used to represent a collection a user owns")
+    pendingDeliveries: TrackableCollection
+    completedDeliveries: TrackableCollection
 }
 
 type Trackable {
@@ -81,8 +83,22 @@ input AddCollaboratorInput {
     username: String!
 }
 
+input AcceptJobInput {
+    user: ID!
+    trackable: ID!
+}
+
+type AcceptJobPayload {
+    trackable: Trackable
+}
+
+input GetTrackablesFilter {
+    owned: Boolean
+}
+
 type Query {
     getTrackable(did: ID!):Trackable
+    getTrackables(filters: GetTrackablesFilter):TrackableCollection
     me: User
 }
 
@@ -93,6 +109,7 @@ type Mutation {
     createTrackable(input:CreateTrackableInput!): CreateTrackablePayload
     addUpdate(input:AddUpdateInput!): AddUpdatePayload
     addCollaborator(input: AddCollaboratorInput!):AddCollaboratorPayload
+    acceptJob(input: AcceptJobInput!):AcceptJobPayload
 }
 `
 


### PR DESCRIPTION
the console.log changes are only here because #9 is in here.

This is the data model changes for https://trello.com/c/b4iB104n/23-driver-summary

It changes the app-wide chaintree to use dids for the drivers as "ownership" of the trackables. I figured this was the easiest thing to do for now...

So create a Trackable, it goes into the list app-wide thing as key/value pair of <did>:false and then when owned it becomes <did>:<didOfOwningUser>

It stays in the app-wide tree for now and filtering can just happen after resolve. Adds the graphql to acceptJob (set the did on the Trackable).

Open question is who should actually "own" a trackable.