### PR TITLE
Fix driver accept button

### DIFF
--- a/src/pages/summary.tsx
+++ b/src/pages/summary.tsx
@@ -17,7 +17,9 @@ const SUMMARY_PAGE_QUERY = gql`
             did
             trackables {
                 did
-                driver
+                driver {
+                    did
+                }
             }
         }
     }
@@ -68,7 +70,7 @@ export function SummaryPage() {
     })
 
     const myTrackables = data.getTrackables.trackables.filter((trackable: Trackable) => {
-        return trackable.driver === data.me.did
+        return trackable.driver?.did === data.me.did
     })
 
     return (

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -137,6 +137,14 @@ const resolvers: Resolvers = {
             const tree = await Tupelo.getLatest(did)
             return (await tree.resolveData("name")).value
         },
+        driver: async (trackable: Trackable, _context): Promise<User | null> => {
+            const tree = await Tupelo.getLatest(trackable.did)
+            const driver = (await tree.resolveData("driver")).value
+            if (!driver) {
+                return null
+            }
+            return { did: driver }
+        },
         image: async (trackable: Trackable, _context): Promise<string> => {
             const did = trackable.did
             const tree = await Tupelo.getLatest(did)
@@ -410,6 +418,7 @@ const resolvers: Resolvers = {
             let c = await communityPromise
 
             await c.playTransactions(trackableTree, [
+                setDataTransaction('driver', loggedinUser.did!),
                 setDataTransaction(`updates/${timestamp}`, update),
                 setOwnershipTransaction([loggedinUser.did])
             ])


### PR DESCRIPTION
When clicking accept, the donation disappeared, this fixes that by setting the driver value. I'm a bit lost on the client only graphql interface here, so maybe there is an easier way to do this?