### PR TITLE
Add status enum for Trackable

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -25,6 +25,14 @@ export type User = {
   completedDeliveries?: Maybe<TrackableCollection>;
 };
 
+export enum TrackableStatus {
+  Created = 'Created',
+  Published = 'Published',
+  Accepted = 'Accepted',
+  PickedUp = 'PickedUp',
+  Delivered = 'Delivered'
+}
+
 export type Trackable = {
    __typename?: 'Trackable';
   did: Scalars['ID'];
@@ -32,6 +40,7 @@ export type Trackable = {
   image?: Maybe<Scalars['String']>;
   updates: TrackableUpdateConnection;
   collaborators?: Maybe<TrackableCollaboratorConnection>;
+  status?: Maybe<TrackableStatus>;
   driver?: Maybe<User>;
 };
 
@@ -266,6 +275,7 @@ export type ResolversTypes = {
   JSON: ResolverTypeWrapper<Scalars['JSON']>,
   User: ResolverTypeWrapper<User>,
   ID: ResolverTypeWrapper<Scalars['ID']>,
+  TrackableStatus: TrackableStatus,
   Trackable: ResolverTypeWrapper<Trackable>,
   TrackableCollaboratorConnection: ResolverTypeWrapper<TrackableCollaboratorConnection>,
   TrackableUpdateConnection: ResolverTypeWrapper<TrackableUpdateConnection>,
@@ -295,6 +305,7 @@ export type ResolversParentTypes = {
   JSON: Scalars['JSON'],
   User: User,
   ID: Scalars['ID'],
+  TrackableStatus: TrackableStatus,
   Trackable: Trackable,
   TrackableCollaboratorConnection: TrackableCollaboratorConnection,
   TrackableUpdateConnection: TrackableUpdateConnection,
@@ -338,6 +349,7 @@ export type TrackableResolvers<ContextType = any, ParentType extends ResolversPa
   image?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   updates?: Resolver<ResolversTypes['TrackableUpdateConnection'], ParentType, ContextType>,
   collaborators?: Resolver<Maybe<ResolversTypes['TrackableCollaboratorConnection']>, ParentType, ContextType>,
+  status?: Resolver<Maybe<ResolversTypes['TrackableStatus']>, ParentType, ContextType>,
   driver?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };

--- a/src/pages/summary.tsx
+++ b/src/pages/summary.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { gql, useQuery, useMutation } from '@apollo/client'
 import { Box, Spinner, Heading, Image, Text, Flex, Button } from '@chakra-ui/core'
-import { Trackable, User } from '../generated/graphql'
+import { Trackable, User, TrackableStatus } from '../generated/graphql'
 import { Link} from 'react-router-dom'
 import Header from '../components/header'
 import debug from 'debug'
@@ -17,6 +17,7 @@ const SUMMARY_PAGE_QUERY = gql`
             did
             trackables {
                 did
+                status
                 driver {
                     did
                 }
@@ -65,12 +66,12 @@ export function SummaryPage() {
         </Box>)
     }
 
-    const unowned = data.getTrackables.trackables.filter((trackable: Trackable) => {
-        return !trackable.driver
+    const available = data.getTrackables.trackables.filter((trackable: Trackable) => {
+        return trackable.status == TrackableStatus.Published
     })
 
     const myTrackables = data.getTrackables.trackables.filter((trackable: Trackable) => {
-        return trackable.driver?.did === data.me.did
+        return trackable.driver?.did === data.me.did && [TrackableStatus.Accepted, TrackableStatus.PickedUp].includes(trackable.status!)
     })
 
     return (
@@ -84,7 +85,7 @@ export function SummaryPage() {
                     </Box>
                     <Box>
                         <Heading>Deliveries needing pickup</Heading>
-                        <TrackableCollection trackables={unowned} user={data.me}/>
+                        <TrackableCollection trackables={available} user={data.me}/>
                     </Box>
                 </Box>
             </Flex>

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -13,12 +13,21 @@ type User {
     completedDeliveries: TrackableCollection
 }
 
+enum TrackableStatus {
+    Created
+    Published
+    Accepted
+    PickedUp
+    Delivered
+}
+
 type Trackable {
     did: ID!
     name: String
     image: String #skynet URL for now
     updates: TrackableUpdateConnection!
     collaborators: TrackableCollaboratorConnection
+    status: TrackableStatus
     driver: User # this is only available on trackables that are part of a collection
 }
 


### PR DESCRIPTION
A Donation flows through an ordinal set of steps / statuses, so added a field to represent this. This makes filtering and routing easier.

I used "enum" in graphql, but I can't figure out how to make it generate an integer based enum, so its just basically storing a string....