### PR TITLE
Feature: make a donation phase 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 public/tupelo.wasm
 
-/ambientUser
-/tupelolocal
+/ambientUser/*
+/tupelolocal/*
+/user/*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,11 @@ import {
   Redirect,
 } from "react-router-dom";
 import { Index } from './pages';
-import { LoginPage } from './pages/login'
-import { RegisterPage } from './pages/register'
-import { DonatePage } from './pages/donate'
+import { LoginPage } from './pages/login';
+import { RegisterPage } from './pages/register';
+import { DonatePage } from './pages/donate';
+import { DonationThanksPage } from './pages/donationThanks';
+import { DonationStatusPage } from './pages/donationStatus';
 import { ObjectPage, LocationWidget } from './pages/object';
 import './store'; // for side effects only
 import { ApolloProvider, useQuery } from '@apollo/client';
@@ -86,6 +88,12 @@ function App() {
             </AuthenticatedRoute>
             <Route path="/donate">
               <DonatePage />
+            </Route>
+            <Route path="/donation/:trackableId/thanks">
+              <DonationThanksPage />
+            </Route>
+            <Route path="/donation/:trackableId">
+              <DonationStatusPage />
             </Route>
             <Route path="/">
               <Index />

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -33,12 +33,6 @@ export enum TrackableStatus {
   Delivered = 'Delivered'
 }
 
-export type EcdsaKey = {
-   __typename?: 'EcdsaKey';
-  publicKey?: Maybe<Scalars['JSON']>;
-  privateKey?: Maybe<Scalars['JSON']>;
-};
-
 export type Trackable = {
    __typename?: 'Trackable';
   did: Scalars['ID'];
@@ -48,7 +42,6 @@ export type Trackable = {
   collaborators?: Maybe<TrackableCollaboratorConnection>;
   status?: Maybe<TrackableStatus>;
   driver?: Maybe<User>;
-  ownerKey?: Maybe<EcdsaKey>;
 };
 
 export type TrackableCollaboratorConnection = {
@@ -99,14 +92,8 @@ export type MetadataEntryInput = {
   value?: Maybe<Scalars['JSON']>;
 };
 
-export type EcdsaKeyInput = {
-  privateKey?: Maybe<Scalars['JSON']>;
-  publicKey?: Maybe<Scalars['JSON']>;
-};
-
 export type AddUpdateInput = {
   trackable: Scalars['ID'];
-  ownerKey?: Maybe<EcdsaKeyInput>;
   message: Scalars['String'];
   metadata?: Maybe<Array<MetadataEntryInput>>;
 };
@@ -289,7 +276,6 @@ export type ResolversTypes = {
   User: ResolverTypeWrapper<User>,
   ID: ResolverTypeWrapper<Scalars['ID']>,
   TrackableStatus: TrackableStatus,
-  EcdsaKey: ResolverTypeWrapper<EcdsaKey>,
   Trackable: ResolverTypeWrapper<Trackable>,
   TrackableCollaboratorConnection: ResolverTypeWrapper<TrackableCollaboratorConnection>,
   TrackableUpdateConnection: ResolverTypeWrapper<TrackableUpdateConnection>,
@@ -299,7 +285,6 @@ export type ResolversTypes = {
   AppCollection: ResolverTypeWrapper<AppCollection>,
   CreateTrackableInput: CreateTrackableInput,
   MetadataEntryInput: MetadataEntryInput,
-  EcdsaKeyInput: EcdsaKeyInput,
   AddUpdateInput: AddUpdateInput,
   CreateTrackablePayload: ResolverTypeWrapper<CreateTrackablePayload>,
   AddUpdatePayload: ResolverTypeWrapper<AddUpdatePayload>,
@@ -321,7 +306,6 @@ export type ResolversParentTypes = {
   User: User,
   ID: Scalars['ID'],
   TrackableStatus: TrackableStatus,
-  EcdsaKey: EcdsaKey,
   Trackable: Trackable,
   TrackableCollaboratorConnection: TrackableCollaboratorConnection,
   TrackableUpdateConnection: TrackableUpdateConnection,
@@ -331,7 +315,6 @@ export type ResolversParentTypes = {
   AppCollection: AppCollection,
   CreateTrackableInput: CreateTrackableInput,
   MetadataEntryInput: MetadataEntryInput,
-  EcdsaKeyInput: EcdsaKeyInput,
   AddUpdateInput: AddUpdateInput,
   CreateTrackablePayload: CreateTrackablePayload,
   AddUpdatePayload: AddUpdatePayload,
@@ -360,12 +343,6 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
-export type EcdsaKeyResolvers<ContextType = any, ParentType extends ResolversParentTypes['EcdsaKey'] = ResolversParentTypes['EcdsaKey']> = {
-  publicKey?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>,
-  privateKey?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>,
-  __isTypeOf?: isTypeOfResolverFn<ParentType>,
-};
-
 export type TrackableResolvers<ContextType = any, ParentType extends ResolversParentTypes['Trackable'] = ResolversParentTypes['Trackable']> = {
   did?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
@@ -374,7 +351,6 @@ export type TrackableResolvers<ContextType = any, ParentType extends ResolversPa
   collaborators?: Resolver<Maybe<ResolversTypes['TrackableCollaboratorConnection']>, ParentType, ContextType>,
   status?: Resolver<Maybe<ResolversTypes['TrackableStatus']>, ParentType, ContextType>,
   driver?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
-  ownerKey?: Resolver<Maybe<ResolversTypes['EcdsaKey']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
@@ -457,7 +433,6 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 export type Resolvers<ContextType = any> = {
   JSON?: GraphQLScalarType,
   User?: UserResolvers<ContextType>,
-  EcdsaKey?: EcdsaKeyResolvers<ContextType>,
   Trackable?: TrackableResolvers<ContextType>,
   TrackableCollaboratorConnection?: TrackableCollaboratorConnectionResolvers<ContextType>,
   TrackableUpdateConnection?: TrackableUpdateConnectionResolvers<ContextType>,

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -33,6 +33,12 @@ export enum TrackableStatus {
   Delivered = 'Delivered'
 }
 
+export type EcdsaKey = {
+   __typename?: 'EcdsaKey';
+  publicKey?: Maybe<Scalars['JSON']>;
+  privateKey?: Maybe<Scalars['JSON']>;
+};
+
 export type Trackable = {
    __typename?: 'Trackable';
   did: Scalars['ID'];
@@ -42,6 +48,7 @@ export type Trackable = {
   collaborators?: Maybe<TrackableCollaboratorConnection>;
   status?: Maybe<TrackableStatus>;
   driver?: Maybe<User>;
+  ownerKey?: Maybe<EcdsaKey>;
 };
 
 export type TrackableCollaboratorConnection = {
@@ -60,8 +67,8 @@ export type TrackableUpdate = {
   timestamp: Scalars['String'];
   message?: Maybe<Scalars['String']>;
   metadata?: Maybe<Array<MetadataEntry>>;
-  userDid: Scalars['String'];
-  userName: Scalars['String'];
+  userDid?: Maybe<Scalars['String']>;
+  userName?: Maybe<Scalars['String']>;
 };
 
 export type MetadataEntry = {
@@ -92,8 +99,14 @@ export type MetadataEntryInput = {
   value?: Maybe<Scalars['JSON']>;
 };
 
+export type EcdsaKeyInput = {
+  privateKey?: Maybe<Scalars['JSON']>;
+  publicKey?: Maybe<Scalars['JSON']>;
+};
+
 export type AddUpdateInput = {
   trackable: Scalars['ID'];
+  ownerKey?: Maybe<EcdsaKeyInput>;
   message: Scalars['String'];
   metadata?: Maybe<Array<MetadataEntryInput>>;
 };
@@ -276,6 +289,7 @@ export type ResolversTypes = {
   User: ResolverTypeWrapper<User>,
   ID: ResolverTypeWrapper<Scalars['ID']>,
   TrackableStatus: TrackableStatus,
+  EcdsaKey: ResolverTypeWrapper<EcdsaKey>,
   Trackable: ResolverTypeWrapper<Trackable>,
   TrackableCollaboratorConnection: ResolverTypeWrapper<TrackableCollaboratorConnection>,
   TrackableUpdateConnection: ResolverTypeWrapper<TrackableUpdateConnection>,
@@ -285,6 +299,7 @@ export type ResolversTypes = {
   AppCollection: ResolverTypeWrapper<AppCollection>,
   CreateTrackableInput: CreateTrackableInput,
   MetadataEntryInput: MetadataEntryInput,
+  EcdsaKeyInput: EcdsaKeyInput,
   AddUpdateInput: AddUpdateInput,
   CreateTrackablePayload: ResolverTypeWrapper<CreateTrackablePayload>,
   AddUpdatePayload: ResolverTypeWrapper<AddUpdatePayload>,
@@ -306,6 +321,7 @@ export type ResolversParentTypes = {
   User: User,
   ID: Scalars['ID'],
   TrackableStatus: TrackableStatus,
+  EcdsaKey: EcdsaKey,
   Trackable: Trackable,
   TrackableCollaboratorConnection: TrackableCollaboratorConnection,
   TrackableUpdateConnection: TrackableUpdateConnection,
@@ -315,6 +331,7 @@ export type ResolversParentTypes = {
   AppCollection: AppCollection,
   CreateTrackableInput: CreateTrackableInput,
   MetadataEntryInput: MetadataEntryInput,
+  EcdsaKeyInput: EcdsaKeyInput,
   AddUpdateInput: AddUpdateInput,
   CreateTrackablePayload: CreateTrackablePayload,
   AddUpdatePayload: AddUpdatePayload,
@@ -343,6 +360,12 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
+export type EcdsaKeyResolvers<ContextType = any, ParentType extends ResolversParentTypes['EcdsaKey'] = ResolversParentTypes['EcdsaKey']> = {
+  publicKey?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>,
+  privateKey?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
 export type TrackableResolvers<ContextType = any, ParentType extends ResolversParentTypes['Trackable'] = ResolversParentTypes['Trackable']> = {
   did?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
@@ -351,6 +374,7 @@ export type TrackableResolvers<ContextType = any, ParentType extends ResolversPa
   collaborators?: Resolver<Maybe<ResolversTypes['TrackableCollaboratorConnection']>, ParentType, ContextType>,
   status?: Resolver<Maybe<ResolversTypes['TrackableStatus']>, ParentType, ContextType>,
   driver?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
+  ownerKey?: Resolver<Maybe<ResolversTypes['EcdsaKey']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
@@ -369,8 +393,8 @@ export type TrackableUpdateResolvers<ContextType = any, ParentType extends Resol
   timestamp?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   metadata?: Resolver<Maybe<Array<ResolversTypes['MetadataEntry']>>, ParentType, ContextType>,
-  userDid?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-  userName?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  userDid?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  userName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
@@ -433,6 +457,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 export type Resolvers<ContextType = any> = {
   JSON?: GraphQLScalarType,
   User?: UserResolvers<ContextType>,
+  EcdsaKey?: EcdsaKeyResolvers<ContextType>,
   Trackable?: TrackableResolvers<ContextType>,
   TrackableCollaboratorConnection?: TrackableCollaboratorConnectionResolvers<ContextType>,
   TrackableUpdateConnection?: TrackableUpdateConnectionResolvers<ContextType>,

--- a/src/pages/donate.tsx
+++ b/src/pages/donate.tsx
@@ -49,38 +49,6 @@ export function DonatePage() {
 
   const { handleSubmit, errors, setError, register, formState } = useForm<DonationData>();
 
-  // const [pickupAddr, setPickupAddr] = useState({} as Address)
-
-  // useEffect(() => {
-  //   if (!donation) {
-  //     log("donation is nil")
-  //     return
-  //   }
-
-  //   log("createDonation result:", donation)
-
-  //   let metadata:MetadataEntry[] = []
-
-  //   metadata.push({key: "location", value: pickupAddr})
-
-  //   // TODO: Add the image once that's working
-  //   //metadata.push(key: "image", value: skylink)
-
-  //   log("adding metadata:", metadata)
-
-  //   // updateDonation({
-  //   //   variables: {
-  //   //     input: {
-  //   //       trackable: donation.trackable!.did, 
-  //   //       message: "ready for pickup",
-  //   //       metadata: metadata,
-  //   //     }}
-  //   // })
-
-  //   // TODO: Do this once the donation is updated
-  //   // setSubmitLoading(false)
-  // }, [pickupAddr, donation])
-
   async function onSubmit({pickupAddr,instructions}:DonationData) {
     setSubmitLoading(true)
     log("submitted:", pickupAddr, instructions);
@@ -91,8 +59,6 @@ export function DonatePage() {
 
     const payload:CreateTrackablePayload = result.data.createUnownedTrackable
     const donation:Trackable = payload.trackable!
-
-    // setPickupAddr(pickupAddr)
 
     log("createDonation result:", donation)
 

--- a/src/pages/donate.tsx
+++ b/src/pages/donate.tsx
@@ -1,10 +1,21 @@
-import { Box, Flex, Button, FormControl, Text, Input, FormErrorMessage, Stack, Textarea } from "@chakra-ui/core";
+import { 
+  Box, 
+  Flex, 
+  Button, 
+  FormControl, 
+  Text, 
+  Input, 
+  FormErrorMessage, 
+  Stack, 
+  Textarea,
+ } from "@chakra-ui/core";
 import React, { useState, useEffect } from 'react';
 import Header from "../components/header";
 import { useForm } from "react-hook-form";
 import { gql, useMutation } from "@apollo/client";
 import debug from "debug";
 import { Trackable, MetadataEntry, CreateTrackablePayload } from '../generated/graphql'
+import { useHistory } from "react-router-dom"
 
 const log = debug("pages.donate")
 
@@ -47,7 +58,9 @@ export function DonatePage() {
   const [createDonation, { error: createError }] = useMutation(CREATE_DONATION_MUTATION)
   const [updateDonation, { error: updateError }] = useMutation(UPDATE_DONATION_MUTATION)
 
-  const { handleSubmit, errors, setError, register, formState } = useForm<DonationData>();
+  const { handleSubmit, errors, register } = useForm<DonationData>();
+
+  const history = useHistory()
 
   async function onSubmit({pickupAddr,instructions}:DonationData) {
     setSubmitLoading(true)
@@ -84,7 +97,7 @@ export function DonatePage() {
         }}
     })
 
-    setSubmitLoading(false)
+    history.push(`/donation/${donation.did}/thanks`)
   }
 
   const [submitLoading, setSubmitLoading] = useState(false)
@@ -95,8 +108,8 @@ export function DonatePage() {
       <Flex mt={5} p={10} flexDirection="column" align="center">
         <Button>Take a Picture</Button>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <Stack spacing={3}>
-            <Text mt={10}>Address for Pickup</Text>
+          <Stack mt={10} spacing={3}>
+            <Text>Address for Pickup</Text>
             <FormControl isInvalid={!!errors.pickupAddr?.street}>
               <Input
                 name="pickupAddr.street"
@@ -130,6 +143,7 @@ export function DonatePage() {
             <Button type="submit" isLoading={submitLoading}>Done</Button>
             <FormErrorMessage>
               {createError && (createError.message)}
+              {updateError && (updateError.message)}
             </FormErrorMessage>
           </Stack>
         </form>

--- a/src/pages/donate.tsx
+++ b/src/pages/donate.tsx
@@ -35,10 +35,6 @@ const CREATE_DONATION_MUTATION = gql`
     createTrackable(input: $input) {
       trackable {
         did
-        ownerKey {
-          publicKey
-          privateKey
-        }
       }
     }
   }
@@ -70,7 +66,7 @@ export function DonatePage() {
       variables: {input: {name: "donation"}}
     })
 
-    const payload:CreateTrackablePayload = result.data.createUnownedTrackable
+    const payload:CreateTrackablePayload = result.data.createTrackable
     const donation:Trackable = payload.trackable!
 
     log("createDonation result:", donation)
@@ -88,10 +84,6 @@ export function DonatePage() {
       variables: {
         input: {
           trackable: donation.did,
-          ownerKey: {
-            privateKey: donation.ownerKey?.privateKey,
-            publicKey: donation.ownerKey?.publicKey,
-          },
           message: "ready for pickup",
           metadata: metadata,
         }}

--- a/src/pages/donationStatus.tsx
+++ b/src/pages/donationStatus.tsx
@@ -1,0 +1,23 @@
+import debug from "debug";
+import React from "react";
+import { Box, Flex, Text } from "@chakra-ui/core";
+import Header from "../components/header";
+import { useParams } from "react-router-dom";
+
+const log = debug("pages.donationStatus")
+
+export function DonationStatusPage() {
+  const { trackableId } = useParams()
+
+  return (
+    <Box>
+      <Header />
+      <Flex mt={5} p={10} flexDirection="column" align="center">
+        <Text>Donation Status for {trackableId}</Text>
+        {
+          // TODO: All of this
+        }
+      </Flex>
+    </Box>
+  )
+}

--- a/src/pages/donationThanks.tsx
+++ b/src/pages/donationThanks.tsx
@@ -1,0 +1,32 @@
+import debug from "debug";
+import React from "react";
+import { Box, Flex, Text, Stack, Button } from "@chakra-ui/core";
+import Header from "../components/header";
+import { Link as RouterLink, useParams } from "react-router-dom";
+
+const log = debug("pages.donationThanks")
+
+export function DonationThanksPage() {
+  const { trackableId } = useParams()
+
+  return (
+    <Box>
+      <Header />
+      <Flex mt={5} p={10} flexDirection="column" align="center">
+        <Stack mt={10} spacing={3}>
+          <Text>Thank you!</Text>
+          <Text>A volunteer is on the way.</Text>
+          <Text>
+            {
+              // TODO: Make "here" link more identifiable; maybe just underline "here"
+            }
+            You can check back <RouterLink to={`/donation/${trackableId}`}>here</RouterLink> to follow your donation on its way to those who need it.
+          </Text>
+          <RouterLink to="/donate">
+            <Button mt={10}>Make Another Donation</Button>
+          </RouterLink>
+        </Stack>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import debug from 'debug';
 import React from 'react';
-import { Box, Flex, Text, Stack, Button } from '@chakra-ui/core';
+import { Box, Flex, Text, Stack, Button, Link } from '@chakra-ui/core';
 import Header from '../components/header';
 import { Link as RouterLink } from 'react-router-dom';
 
@@ -27,6 +27,10 @@ export function Index() {
             leaving it and our volunteers will be there to pick it up and get
             it where it is needed.
           </Text>
+
+          <Link href="https://www.netlify.com/" mt={10} isExternal>
+            This site is powered by Netlify
+          </Link>
         </Stack>
       </Flex>
     </Box> 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { Box, Flex, FormControl, FormLabel, FormErrorMessage, Button, Input, Heading, Link} from '@chakra-ui/core'
 import { useForm } from "react-hook-form";
-import { Redirect, Link as RouterLink} from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 import { useMutation,gql } from '@apollo/client';
 import {userNamespace} from '../store/index'
 
@@ -105,10 +105,6 @@ export function LoginPage() {
                     </Button>
                 </form>
             </Box>
-
-            <Link href="https://www.netlify.com/" mt={10} isExternal>
-                This site is powered by Netlify
-            </Link>
         </Flex>
     )
 }

--- a/src/store/index.spec.ts
+++ b/src/store/index.spec.ts
@@ -34,9 +34,6 @@ describe('resolvers', () => {
         const CREATE_TRACKABLE = gql`
             mutation CreateTrackable($input: CreateTrackableInput!) {
                 createTrackable(input: $input) {
-                    collection {
-                        did
-                    }
                     trackable {
                         did
                         name
@@ -46,18 +43,18 @@ describe('resolvers', () => {
             }
         `
 
-                // it adds to the app collection
-            const appTrackableQuery = gql`
-               {
-                    getTrackables {
+        // it adds to the app collection
+        const appTrackableQuery = gql`
+            {
+                getTrackables {
+                    did
+                    trackables {
                         did
-                        trackables {
-                            did
-                            driver
-                        }
+                        driver
                     }
                 }
-            `
+            }
+        `
 
         const mutateResp = await client.mutate({
             mutation: CREATE_TRACKABLE,

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -21,6 +21,11 @@ enum TrackableStatus {
     Delivered
 }
 
+type EcdsaKey {
+    publicKey: JSON
+    privateKey: JSON
+}
+
 type Trackable {
     did: ID!
     name: String
@@ -29,6 +34,7 @@ type Trackable {
     collaborators: TrackableCollaboratorConnection
     status: TrackableStatus
     driver: User # this is only available on trackables that are part of a collection
+    ownerKey: EcdsaKey
 }
 
 type TrackableCollaboratorConnection {
@@ -44,8 +50,8 @@ type TrackableUpdate {
     timestamp: String! # ISO standard string
     message: String
     metadata: [MetadataEntry!]
-    userDid: String!
-    userName: String!
+    userDid: String
+    userName: String
 }
 
 type MetadataEntry {
@@ -75,8 +81,14 @@ input MetadataEntryInput {
     value: JSON
 }
 
+input EcdsaKeyInput {
+    privateKey: JSON
+    publicKey: JSON
+}
+
 input AddUpdateInput {
     trackable: ID!
+    ownerKey: EcdsaKeyInput
     message: String!
     metadata: [MetadataEntryInput!]
 }

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -21,11 +21,6 @@ enum TrackableStatus {
     Delivered
 }
 
-type EcdsaKey {
-    publicKey: JSON
-    privateKey: JSON
-}
-
 type Trackable {
     did: ID!
     name: String
@@ -34,7 +29,6 @@ type Trackable {
     collaborators: TrackableCollaboratorConnection
     status: TrackableStatus
     driver: User # this is only available on trackables that are part of a collection
-    ownerKey: EcdsaKey
 }
 
 type TrackableCollaboratorConnection {
@@ -81,14 +75,8 @@ input MetadataEntryInput {
     value: JSON
 }
 
-input EcdsaKeyInput {
-    privateKey: JSON
-    publicKey: JSON
-}
-
 input AddUpdateInput {
     trackable: ID!
-    ownerKey: EcdsaKeyInput
     message: String!
     metadata: [MetadataEntryInput!]
 }


### PR DESCRIPTION
This adds most of the rest of the donation flow and shows the pickup location data of donations on the `/summary` page.

There are still some things unimplemented, which I've hopefully documented with `TODO:` comments. The big ones are image uploading and the donation status page (with the date, pickup, dropoff sections in the wireframe).

But this seemed like a coherent state to merge if everything looks OK.