### PR TITLE
split accept jobs to separate screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { ApolloProvider, useQuery } from '@apollo/client';
 import { client } from './store/index';
 import { CURRENT_USER } from './store/queries';
 import { SummaryPage } from './pages/summary';
+import { PickUpsPage } from './pages/pickups';
 
 // A wrapper for <Route> that redirects to the login
 // screen if you're not yet authenticated.
@@ -85,6 +86,9 @@ function App() {
                         </AuthenticatedRoute>
                         <AuthenticatedRoute path="/summary">
                             <SummaryPage />
+                        </AuthenticatedRoute>
+                        <AuthenticatedRoute path="/pickups">
+                            <PickUpsPage />
                         </AuthenticatedRoute>
                         <Route path="/donate">
                             <DonatePage />

--- a/src/pages/pickups.tsx
+++ b/src/pages/pickups.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { gql, useQuery, useMutation } from '@apollo/client'
 import { Box, Spinner, Heading, Image, Text, Flex, Button, Icon } from '@chakra-ui/core'
 import { Trackable, User, TrackableStatus } from '../generated/graphql'
-import { Link} from 'react-router-dom'
+import { getUrl } from '../lib/skynet'
 import { useHistory } from "react-router-dom";
 import Header from '../components/header'
 import debug from 'debug'
@@ -18,6 +18,7 @@ const PICKUPS_PAGE_QUERY = gql`
             did
             trackables {
                 did
+                image
                 status
             }
         }
@@ -108,14 +109,14 @@ function TrackableCollection({ trackables,user }: { trackables: Trackable[],user
 
     const trackableElements = trackables.map((trackable: Trackable) => {
         return (
-          <Box p="5" ml="2" maxW="sm" borderWidth="1px" rounded="lg" overflow="hidden" key={trackable.did}>
-              {/* {trackable.image &&
-                  <Image src={getUrl(trackable.image)} />
-              } */}
-              <Text> TODO: Pick Up Address </Text>
-              <Text> TODO: Drop Off Address </Text>
-              { AcceptJobButton({trackable, user}) }
-          </Box>
+            <Box p="5" ml="2" maxW="sm" borderWidth="1px" rounded="lg" overflow="hidden" key={trackable.did}>
+                {trackable.image &&
+                    <Image src={getUrl(trackable.image)} />
+                }
+                <Text> TODO: Pick Up Address </Text>
+                <Text> TODO: Drop Off Address </Text>
+                { AcceptJobButton({trackable, user}) }
+            </Box>
         )
     })
     return (

--- a/src/pages/pickups.tsx
+++ b/src/pages/pickups.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { gql, useQuery, useMutation } from '@apollo/client'
+import { Box, Spinner, Heading, Image, Text, Flex, Button, Icon } from '@chakra-ui/core'
+import { Trackable, User, TrackableStatus } from '../generated/graphql'
+import { Link} from 'react-router-dom'
+import { useHistory } from "react-router-dom";
+import Header from '../components/header'
+import debug from 'debug'
+
+const log = debug("pages.pickups")
+
+const PICKUPS_PAGE_QUERY = gql`
+    query PickUpsPage($filters: GetTrackablesFilter) {
+        me {
+            did
+        }
+        getTrackables(filters: $filters) {
+            did
+            trackables {
+                did
+                status
+            }
+        }
+    }
+`
+const ACCEPT_JOB_MUTATION = gql`
+    mutation PickUpsPageAccept($input: AcceptJobInput!) {
+        acceptJob(input: $input) {
+            code
+        }
+    }
+`
+
+export function PickUpsPage() {
+    const { data, loading, error } = useQuery(PICKUPS_PAGE_QUERY)
+
+    if (loading) {
+        return (
+            <Box>
+                <Spinner />
+            </Box>
+        )
+    }
+
+    if (error) {
+        return (
+            <Box>
+                <Text>{error}</Text>
+            </Box>
+        )
+    }
+
+    log("pickups page data: ", data)
+
+    if (data.getTrackables?.trackables?.length == 0) {
+        return (<Box>
+            <Header />
+            <Flex mt={5} p={10} flexDirection="column">
+                <Box>
+                    <Box>
+                        <Heading>No donations available for pickup.</Heading>
+                    </Box>
+                </Box>
+            </Flex>
+        </Box>)
+    }
+
+    const available = data.getTrackables.trackables.filter((trackable: Trackable) => {
+        return trackable.status == TrackableStatus.Published
+    })
+
+    return (
+        <Box>
+            <Header />
+            <Flex mt={5} p={10} flexDirection="column">
+                <Box>
+                    <Box>
+                        <TrackableCollection trackables={available} user={data.me} />
+                    </Box>
+                </Box>
+            </Flex>
+        </Box>
+    )
+}
+
+function AcceptJobButton({trackable, user}:{trackable:Trackable, user:User}) {
+    const [acceptJob] = useMutation(ACCEPT_JOB_MUTATION)
+    const history = useHistory()
+
+    const onClick = async ()=> {
+        await acceptJob({
+            variables: {
+                input: {
+                    trackable: trackable.did,
+                    user: user.did,
+                }
+            },
+        })
+        history.push('/summary')
+    }
+
+    return (
+        <Button onClick={onClick}>Accept Job</Button>
+    )
+}
+
+function TrackableCollection({ trackables,user }: { trackables: Trackable[],user:User }) {
+
+    const trackableElements = trackables.map((trackable: Trackable) => {
+        return (
+          <Box p="5" ml="2" maxW="sm" borderWidth="1px" rounded="lg" overflow="hidden" key={trackable.did}>
+              {/* {trackable.image &&
+                  <Image src={getUrl(trackable.image)} />
+              } */}
+              <Text> TODO: Pick Up Address </Text>
+              <Text> TODO: Drop Off Address </Text>
+              { AcceptJobButton({trackable, user}) }
+          </Box>
+        )
+    })
+    return (
+        <>
+            {trackableElements}
+        </>
+    )
+}


### PR DESCRIPTION
modifies the pages to follow the mockups - pickup / drop off screens are not yet implemented and just links to the existing objects page