### PR TITLE
Fix ownership bug on donation page

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -76,6 +76,12 @@ export type TrackableCollection = {
     trackables?: Maybe<Array<Trackable>>;
 };
 
+export type Address = {
+    __typename?: 'Address';
+    street?: Maybe<Scalars['String']>;
+    cityStateZip?: Maybe<Scalars['String']>;
+};
+
 export type AppCollection = {
     __typename?: 'AppCollection';
     did: Scalars['ID'];
@@ -85,6 +91,13 @@ export type AppCollection = {
 export type CreateTrackableInput = {
     name: Scalars['String'];
     image?: Maybe<Scalars['String']>;
+    address?: Maybe<AddressInput>;
+    instructions?: Maybe<Scalars['String']>;
+};
+
+export type AddressInput = {
+    street: Scalars['String'];
+    cityStateZip: Scalars['String'];
 };
 
 export type MetadataEntryInput = {
@@ -282,8 +295,10 @@ export type ResolversTypes = {
     TrackableUpdate: ResolverTypeWrapper<TrackableUpdate>,
     MetadataEntry: ResolverTypeWrapper<MetadataEntry>,
     TrackableCollection: ResolverTypeWrapper<TrackableCollection>,
+    Address: ResolverTypeWrapper<Address>,
     AppCollection: ResolverTypeWrapper<AppCollection>,
     CreateTrackableInput: CreateTrackableInput,
+    AddressInput: AddressInput,
     MetadataEntryInput: MetadataEntryInput,
     AddUpdateInput: AddUpdateInput,
     CreateTrackablePayload: ResolverTypeWrapper<CreateTrackablePayload>,
@@ -312,8 +327,10 @@ export type ResolversParentTypes = {
     TrackableUpdate: TrackableUpdate,
     MetadataEntry: MetadataEntry,
     TrackableCollection: TrackableCollection,
+    Address: Address,
     AppCollection: AppCollection,
     CreateTrackableInput: CreateTrackableInput,
+    AddressInput: AddressInput,
     MetadataEntryInput: MetadataEntryInput,
     AddUpdateInput: AddUpdateInput,
     CreateTrackablePayload: CreateTrackablePayload,
@@ -386,6 +403,12 @@ export type TrackableCollectionResolvers<ContextType = any, ParentType extends R
     __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 
+export type AddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['Address'] = ResolversParentTypes['Address']> = {
+    street?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+    cityStateZip?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+    __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
 export type AppCollectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['AppCollection'] = ResolversParentTypes['AppCollection']> = {
     did?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
     trackables?: Resolver<Maybe<Array<ResolversTypes['Trackable']>>, ParentType, ContextType>,
@@ -439,6 +462,7 @@ export type Resolvers<ContextType = any> = {
     TrackableUpdate?: TrackableUpdateResolvers<ContextType>,
     MetadataEntry?: MetadataEntryResolvers<ContextType>,
     TrackableCollection?: TrackableCollectionResolvers<ContextType>,
+    Address?: AddressResolvers<ContextType>,
     AppCollection?: AppCollectionResolvers<ContextType>,
     CreateTrackablePayload?: CreateTrackablePayloadResolvers<ContextType>,
     AddUpdatePayload?: AddUpdatePayloadResolvers<ContextType>,

--- a/src/pages/summary.tsx
+++ b/src/pages/summary.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { gql, useQuery } from '@apollo/client'
-import { Box, Spinner, Heading, Image, Text, Flex, Icon } from '@chakra-ui/core'
-import { Link } from "react-router-dom";
+import { Box, Spinner, Heading, Image, Text, Flex } from '@chakra-ui/core'
 import { Trackable, User, TrackableStatus } from '../generated/graphql'
 import { getUrl } from '../lib/skynet'
 import Header from '../components/header'
@@ -21,16 +20,6 @@ const SUMMARY_PAGE_QUERY = gql`
                 status
                 name
                 image
-                updates {
-                    edges {
-                        timestamp
-                        message
-                        metadata {
-                            key
-                            value
-                        }
-                    }
-                }
                 driver {
                     did
                 }

--- a/src/pages/summary.tsx
+++ b/src/pages/summary.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { gql, useQuery } from '@apollo/client'
-import { Box, Spinner, Heading, Image, Text, Flex } from '@chakra-ui/core'
+import { Box, Spinner, Heading, Image, Icon, Text, Flex } from '@chakra-ui/core'
 import { Trackable, User, TrackableStatus } from '../generated/graphql'
+import { Link } from 'react-router-dom';
 import { getUrl } from '../lib/skynet'
 import Header from '../components/header'
 import debug from 'debug'

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -58,6 +58,11 @@ type TrackableCollection {
     trackables: [Trackable!]
 }
 
+type Address {
+    street: String
+    cityStateZip: String
+}
+
 # AppCollection is kept as a separate type from TrackableCollection
 # because of how they are updated
 type AppCollection {
@@ -68,6 +73,13 @@ type AppCollection {
 input CreateTrackableInput {
     name: String!
     image: String
+    address: AddressInput
+    instructions: String
+}
+
+input AddressInput {
+    street: String!
+    cityStateZip: String!
 }
 
 input MetadataEntryInput {


### PR DESCRIPTION
Because there was a `setOwnership` inside the `createTrackable`, the following metadata update was failing. This changes it around so that all the data for creation is passed in `createTrackable` with a single `playTransaction`