### PR TITLE
Resize and compress donation pics before uploading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16838,6 +16838,11 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.1.3.tgz",
       "integrity": "sha512-6+6wSge72A2Y7WGqMke4afOz0uDJ3gOPSysmYKkjJszSbmw8X8at7tJPzifnZ+cwLDR88b4on/D+jfH5azWbIw=="
     },
+    "react-image-file-resizer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/react-image-file-resizer/-/react-image-file-resizer-0.2.3.tgz",
+      "integrity": "sha512-IyNDL3Ybdq3MI4IIvlb2kw+rF5JCBKExBOx7liphp9Qo+8iiNkkEGMyjoaRFUJcw97GklpWYqAiI9lwopElGOg=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-hook-form": "^5.1.3",
+    "react-image-file-resizer": "^0.2.3",
     "react-leaflet": "^2.6.3",
     "react-qrcode-logo": "^2.2.1",
     "react-router-dom": "^5.1.2",

--- a/src/@types/react-image-file-resizer/index.d.ts
+++ b/src/@types/react-image-file-resizer/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'react-image-file-resizer' {
+    import Resizer from 'react-image-file-resizer';
+
+    export default Resizer
+}

--- a/src/lib/skynet.ts
+++ b/src/lib/skynet.ts
@@ -3,15 +3,10 @@ import axios from "axios";
 
 const PORTAL_URI = "https://siasky.net"
 
-export async function upload(fileList: FileList, options = {}) {
+export async function upload(file: Blob|File, options = {}) {
     const formData = new FormData();
-    if (fileList.length === 0) {
-        throw new Error("you must have a file to upload")
-    }
 
-    const file = fileList.item(0)?.slice()
-
-    formData.append("file", file!);
+    formData.append("file", file);
 
     const parsed = parse(PORTAL_URI);
 

--- a/src/pages/object.tsx
+++ b/src/pages/object.tsx
@@ -287,7 +287,7 @@ export function ObjectPage() {
             metadata.push({ key: "location", value: geoPositonToPojo(location.coords) })
         }
         if (data.image && data.image.length > 0) {
-            const { skylink } = await upload(data.image, {});
+            const { skylink } = await upload(data.image.item(0)!, {});
             metadata.push({ key: "image", value: skylink })
         }
         setShow(false)

--- a/src/pages/trackable.tsx
+++ b/src/pages/trackable.tsx
@@ -66,7 +66,7 @@ export function TrackablePage() {
         let skylink: string | undefined = undefined
 
         if (image && image.length > 0) {
-            const resp = await upload(image, {});
+            const resp = await upload(image.item(0)!, {});
             log("skylink: ", resp.skylink)
             skylink = resp.skylink
         }


### PR DESCRIPTION
This is my first time writing a TypeScript declaration file, so it's probably wrong. There are approximately 11,082,473,267 different ways to structure Javascript code, so reading the docs and examples wasn't very enlightening. But... it works! So... :shipit:.

This resizes images to 300px max in either dimension, converts it to JPEG, and sets the JPEG compression quality to 90%.

Here's the image I tested it with: 
![IMG_2125](https://user-images.githubusercontent.com/59748/80756541-f1fe1980-8aef-11ea-9ee6-eb498f9a41c3.png)
