### PR TITLE
Fix up undefined image error on summary page

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -143,11 +143,6 @@ export type AcceptJobPayload = {
     trackable?: Maybe<Trackable>;
 };
 
-export type GetTrackablesFilter = {
-    owned?: Maybe<Scalars['Boolean']>;
-    ownedBy?: Maybe<Scalars['String']>;
-};
-
 export type Query = {
     __typename?: 'Query';
     getTrackable?: Maybe<Trackable>;
@@ -308,7 +303,6 @@ export type ResolversTypes = {
     AddCollaboratorInput: AddCollaboratorInput,
     AcceptJobInput: AcceptJobInput,
     AcceptJobPayload: ResolverTypeWrapper<AcceptJobPayload>,
-    GetTrackablesFilter: GetTrackablesFilter,
     Query: ResolverTypeWrapper<{}>,
     Mutation: ResolverTypeWrapper<{}>,
 };
@@ -340,7 +334,6 @@ export type ResolversParentTypes = {
     AddCollaboratorInput: AddCollaboratorInput,
     AcceptJobInput: AcceptJobInput,
     AcceptJobPayload: AcceptJobPayload,
-    GetTrackablesFilter: GetTrackablesFilter,
     Query: {},
     Mutation: {},
 };

--- a/src/pages/summary.tsx
+++ b/src/pages/summary.tsx
@@ -10,11 +10,11 @@ import debug from 'debug'
 const log = debug("pages.summary")
 
 const SUMMARY_PAGE_QUERY = gql`
-    query SummaryPage($filters: GetTrackablesFilter) {
+    {
         me {
             did
         }
-        getTrackables(filters: $filters) {
+        getTrackables {
             did
             trackables {
                 did
@@ -33,24 +33,29 @@ export function SummaryPage() {
     const { data, loading, error } = useQuery(SUMMARY_PAGE_QUERY)
     if (loading) {
         return (
-            <Flex align="center" justify="center" h="100%">
-                <Spinner />
-                <Text ml="1rem">Loading donations</Text>
-            </Flex>
+            <Box>
+                <Header />
+                <Flex align="center" justify="center" h="100%">
+                    <Spinner />
+                    <Text ml="1rem">Loading donations</Text>
+                </Flex>
+            </Box>
         )
     }
 
     if (error) {
+        console.error(error)
         return (
             <Box>
-                <Text>{error}</Text>
+                <Text>{error.message}:</Text>
+                <code>{error.stack}</code>
             </Box>
         )
     }
 
     log("summary page data: ", data)
 
-    if (data.getTrackables?.trackables?.length == 0) {
+    if (data.getTrackables?.trackables?.length === 0) {
         return (<Box>
             <Header />
             <Flex mt={5} p={10} flexDirection="column">
@@ -64,14 +69,14 @@ export function SummaryPage() {
     }
 
     const available = data.getTrackables.trackables.filter((trackable: Trackable) => {
-        return trackable.status == TrackableStatus.Published
+        return trackable.status === TrackableStatus.Published
     })
 
     const myTrackables = data.getTrackables.trackables.filter((trackable: Trackable) => {
         return trackable.driver?.did === data.me.did && [TrackableStatus.Accepted, TrackableStatus.PickedUp].includes(trackable.status!)
     })
 
-    console.log(myTrackables)
+    log("myTrackables: ", myTrackables)
 
     return (
         <Box>
@@ -79,7 +84,7 @@ export function SummaryPage() {
             <Flex mt={5} p={10} flexDirection="column">
                 <Box>
                     <Box mt="2" color="gray.600" fontSize="sm">
-                        <Link to={`/pickups`}>Find more Deliveries <br /> ({available.length} Available) </Link> 
+                        <Link to="/pickups">Find more Deliveries <br /> ({available.length} Available) </Link> 
                     </Box>
                     <Box>
                         <Heading mb={3}>Your current deliveries</Heading>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,7 +25,7 @@ import {
     TrackableStatus,
     MetadataEntry,
 } from '../generated/graphql'
-import { Tupelo, Community, ChainTree, EcdsaKey, setDataTransaction, setOwnershipTransaction } from 'tupelo-wasm-sdk'
+import { Tupelo, Community, ChainTree, EcdsaKey, setDataTransaction, setOwnershipTransaction, IResolveResponse } from 'tupelo-wasm-sdk'
 import { AppUser } from './user';
 import { makeExecutableSchema } from 'graphql-tools';
 import { SchemaLink } from '@apollo/link-schema';
@@ -56,6 +56,22 @@ function namespaceToPath(namespace: string) {
 const appCollection = new AppCollection({ name: `${userNamespace}/trackables`, namespace: userNamespace })
 
 const drivers = new Drivers({ region: 'princeton, nj', namespace: `${userNamespace}/drivers` })
+
+// there is a crappy IPLD bug where if you're resolving to something that has a value of undefined
+// then IPLD will error with 'Cannot convert undefined or null to object'
+const resolveWithUndefined = async (tree:ChainTree, path:string):Promise<IResolveResponse> => {
+    try {
+        return await tree.resolveData(path)
+    } catch(err) {
+        if (err.message.includes('Cannot convert undefined or null to object')) {
+            return {
+                remainderPath: [],
+                value: undefined,
+            }
+        }
+        throw err
+    }
+}
 
 /**
  * Looks up the user account chaintree for the given username, returning it if
@@ -137,26 +153,31 @@ const resolvers: Resolvers = {
             log("name trackable: ", trackable)
             const did = trackable.did
             const tree = await Tupelo.getLatest(did)
-            return (await tree.resolveData("name")).value
+            return (await resolveWithUndefined(tree, "name")).value
         },
         status: async (trackable: Trackable, _context): Promise<TrackableStatus | null> => {
+            log("status trackable: ", trackable)
             const tree = await Tupelo.getLatest(trackable.did)
-            return (await tree.resolveData("status")).value
+            return (await resolveWithUndefined(tree, "status")).value
         },
         driver: async (trackable: Trackable, _context): Promise<User | null> => {
+            log("driver trackable: ", trackable)
             const tree = await Tupelo.getLatest(trackable.did)
-            const driver = (await tree.resolveData("driver")).value
+            const driver = (await resolveWithUndefined(tree, "driver")).value
             if (!driver) {
                 return null
             }
             return { did: driver }
         },
-        image: async (trackable: Trackable, _context): Promise<string> => {
+        image: async (trackable: Trackable, _context): Promise<string | null> => {
+            log("image trackable: ", trackable)
             const did = trackable.did
             const tree = await Tupelo.getLatest(did)
-            return (await tree.resolveData("image")).value
+            return (await resolveWithUndefined(tree, "image")).value 
         },
         updates: async (trackable: Trackable, _context): Promise<TrackableUpdateConnection> => {
+            log("updates trackable: ", trackable)
+
             const did = trackable.did
             const tree = await Tupelo.getLatest(did)
             let updates = await tree.resolveData("updates")
@@ -181,7 +202,7 @@ const resolvers: Resolvers = {
         trackables: async (collection: TrackableCollection, _context): Promise<Trackable[]> => {
             const tree = await Tupelo.getLatest(collection.did)
             // this will be a map of timestamp to did
-            const trackableResp = (await tree.resolveData("updates"))
+            const trackableResp = (await resolveWithUndefined(tree, "updates"))
             log(trackableResp)
             const trackables = trackableResp.value
             if (!trackables) {

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -121,11 +121,6 @@ type AcceptJobPayload {
     trackable: Trackable
 }
 
-input GetTrackablesFilter {
-    owned: Boolean
-    ownedBy: String
-}
-
 type Query {
     getTrackable(did: ID!):Trackable
     getTrackables:AppCollection


### PR DESCRIPTION
The summary page would error on a donation without an image. That's because IPLD errors when it tries to return a result that is null/undefined - this adds a function to correct that... should go down in the IPLD level at some point.

Mixed in here (sorry) are a couple of minor cleanups to logs/unused-types.

