### PR TITLE
Fix failing trackable query test

### DIFF
--- a/src/store/index.spec.ts
+++ b/src/store/index.spec.ts
@@ -74,8 +74,8 @@ describe('resolvers', () => {
 
     it('queries trackables', async () => {
         const query = gql`
-            query GetTrackables($filters: GetTrackablesFilter) {
-                getTrackables(filters: $filters) {
+            query GetTrackables {
+                getTrackables {
                     did
                     trackables {
                         did


### PR DESCRIPTION
Noticed this test was failing after recent removal of filter arg on the `getTrackables` query.