### PR TITLE
add metadata to Trackable (and some cleanup)

### DIFF
--- a/src/components/pickupaddr.tsx
+++ b/src/components/pickupaddr.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { Text } from '@chakra-ui/core'
+import {AddressInput} from '../generated/graphql'
 
 
-export function PickupAddr({addr}:{addr:{street:string,cityStateZip:string}|undefined}) {
+export function PickupAddr({addr}:{addr:AddressInput|undefined}) {
     if (!addr) {
         return <Text>Unknown pickup address</Text>
     }

--- a/src/components/pickupaddr.tsx
+++ b/src/components/pickupaddr.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Text } from '@chakra-ui/core'
+
+
+export function PickupAddr({addr}:{addr:{street:string,cityStateZip:string}|undefined}) {
+    if (!addr) {
+        return <Text>Unknown pickup address</Text>
+    }
+    return (
+        <Text> 
+            {addr.street}<br/>
+            {addr.cityStateZip}
+        </Text>
+    )
+}
+
+export default PickupAddr

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -42,6 +42,7 @@ export type Trackable = {
     collaborators?: Maybe<TrackableCollaboratorConnection>;
     status?: Maybe<TrackableStatus>;
     driver?: Maybe<User>;
+    metadata?: Maybe<Array<MetadataEntry>>;
 };
 
 export type TrackableCollaboratorConnection = {
@@ -361,6 +362,7 @@ export type TrackableResolvers<ContextType = any, ParentType extends ResolversPa
     collaborators?: Resolver<Maybe<ResolversTypes['TrackableCollaboratorConnection']>, ParentType, ContextType>,
     status?: Resolver<Maybe<ResolversTypes['TrackableStatus']>, ParentType, ContextType>,
     driver?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
+    metadata?: Resolver<Maybe<Array<ResolversTypes['MetadataEntry']>>, ParentType, ContextType>,
     __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 

--- a/src/pages/donationStatus.tsx
+++ b/src/pages/donationStatus.tsx
@@ -45,18 +45,14 @@ export function DonationStatusPage() {
     }
 
     const enhancedUpdates = trackable.updates.edges?.map((u: TrackableUpdate) => {
-        let eu = Object.assign(Object.create({}), u)
-        
-        eu.timestampDate = new Date(u.timestamp)
-
-        const image = u.metadata?.find((m) => m.key === "image")?.value
-
-        eu.image = image
-
-        return eu
+        return {
+            ...u,
+            timestampDate: new Date(u.timestamp),
+            image: u.metadata?.find((m) => m.key === "image")?.value,
+        }
     })
 
-    const sortedUpdates = enhancedUpdates?.sort((a, b) => b.timestampDate - a.timestampDate)
+    const sortedUpdates = enhancedUpdates?.sort((a, b) => b.timestampDate.getTime() - a.timestampDate.getTime())
     const firstUpdate = sortedUpdates && sortedUpdates[0]
     const restUpdates = sortedUpdates?.slice(1)
 

--- a/src/pages/summary.tsx
+++ b/src/pages/summary.tsx
@@ -6,10 +6,11 @@ import { Link } from 'react-router-dom';
 import { getUrl } from '../lib/skynet'
 import Header from '../components/header'
 import debug from 'debug'
+import PickupAddr from '../components/pickupaddr';
 
 const log = debug("pages.summary")
 
-const SUMMARY_PAGE_QUERY = gql`
+export const SUMMARY_PAGE_QUERY = gql`
     {
         me {
             did
@@ -21,6 +22,10 @@ const SUMMARY_PAGE_QUERY = gql`
                 status
                 name
                 image
+                metadata {
+                    key
+                    value
+                }
                 driver {
                     did
                 }
@@ -110,6 +115,7 @@ function TrackableCollection({ trackables, user }: { trackables: Trackable[], us
                 break;
             }
         }
+        const pickupAddr = trackable.metadata?.find((m) => m.key === "location")?.value
 
         return (
             <Link to={link} key={trackable.did}>
@@ -120,7 +126,7 @@ function TrackableCollection({ trackables, user }: { trackables: Trackable[], us
                     { trackable.status == TrackableStatus.PickedUp ?
                         <Text> <Icon name="check" /> Picked Up</Text>
                     :
-                        <Text> TODO: Pick Up Address </Text>
+                        <PickupAddr addr={pickupAddr}/>
                     }
                     <Text> TODO: Drop Off Address </Text>
                 </Box>

--- a/src/pages/trackable.tsx
+++ b/src/pages/trackable.tsx
@@ -90,7 +90,7 @@ export function TrackablePage() {
             },
             update: (proxy, { data: { createTrackable } }) => {
                 const data: any = proxy.readQuery({ query: GET_TRACKABLES })
-                console.log("update called: ", createTrackable, " readQuery: ", data)
+                log("update called: ", createTrackable, " readQuery: ", data)
                 // data.me.collection.trackables.push(createTrackable.trackable)
                 // TODO: this should be a deep merge
                 proxy.writeQuery({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -189,6 +189,14 @@ const resolvers: Resolvers = {
             const tree = await Tupelo.getLatest(did)
             return (await resolveWithUndefined(tree, "image")).value 
         },
+        metadata: async (trackable: Trackable, _context): Promise<MetadataEntry[]> => {
+            if (trackable.metadata) {
+                return trackable.metadata
+            }
+            log("trackable metadata")
+            const tree = await Tupelo.getLatest(trackable.did)
+            return (await resolveWithUndefined(tree, "metadata")).value 
+        },
         updates: async (trackable: Trackable, _context): Promise<TrackableUpdateConnection> => {
             log("updates trackable: ", trackable)
 
@@ -276,10 +284,8 @@ const resolvers: Resolvers = {
                 name: input.name,
                 image: input.image,
                 status: TrackableStatus.Published,
+                metadata: [{ key: "location", value: input.address }],
             }
-
-            let metadata: MetadataEntry[] = []
-            metadata.push({ key: "location", value: input.address })
 
             let message = "ready for pickup"
             if ((input?.instructions?.trim() || "").length > 0) {
@@ -291,7 +297,6 @@ const resolvers: Resolvers = {
                 did: `${(await tree.id())}-${timestamp}`,
                 timestamp: timestamp,
                 message: message,
-                metadata: metadata,
             }
 
             log("playing Tupelo transactions for trackable")
@@ -486,7 +491,7 @@ const resolvers: Resolvers = {
                 userDid: loggedinUser.did!,
                 userName: loggedinUser.userName,
             }
-            console.log("update: ", update)
+            log("update: ", update)
             let c = await communityPromise
 
             await c.playTransactions(trackableTree, [

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -29,6 +29,7 @@ type Trackable {
     collaborators: TrackableCollaboratorConnection
     status: TrackableStatus
     driver: User # this is only available on trackables that are part of a collection
+    metadata: [MetadataEntry!]
 }
 
 type TrackableCollaboratorConnection {


### PR DESCRIPTION
I was about to go write another weird place to get the address of the trackable and didn't want to add more debt, so did a super simple refactor to add metadata to the trackable itself and use that for the location.

There's also a bit of cleanup here... getting rid of weird Object.assign stuff, refreshing queries after the accept job, logging cleanup, etc.