### PR TITLE
fix up the accept button

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -377,20 +377,16 @@ const resolvers: Resolvers = {
 
         },
         addUpdate: async (_root, { input: { trackable, message, metadata } }: MutationAddUpdateArgs, { communityPromise }: TrackerContext): Promise<AddUpdatePayload | undefined> => {
-            let user
-            if (appUser.userPromise) {
-                log("loading current user")
-                const userResp = await appUser.userPromise
-                if (userResp !== undefined) {
-                    user = userResp!
-                    await user.load()
-                }
+            const user = await appUser.userPromise
+            await user?.load()
+            if (!user) {
+                throw new Error("you must be logged in to make an update")
             }
 
             let timestamp = (new Date()).toISOString()
 
             const trackableTree = await Tupelo.getLatest(trackable)
-            trackableTree.key = await drivers.key()
+            trackableTree.key = user.tree.key
 
             let update: TrackableUpdate = {
                 did: `${(await trackableTree.id())}-${timestamp}`,
@@ -488,12 +484,15 @@ const resolvers: Resolvers = {
             }
             console.log("update: ", update)
             let c = await communityPromise
+            const driversTree = await drivers.treePromise
+            const driversDid = await driversTree.id()
 
             await c.playTransactions(trackableTree, [
                 setDataTransaction('driver', loggedinUser.did!),
                 setDataTransaction('status', TrackableStatus.Accepted),
                 setDataTransaction(`updates/${timestamp}`, update),
-                setOwnershipTransaction([loggedinUser.did])
+                setOwnershipTransaction([loggedinUser.did, driversDid!]),
+                setDataTransaction(`collaborators/${loggedinUser.did}`, true),
             ])
 
             // then mark it owned on the appCollection


### PR DESCRIPTION
This has the accept button make the object owned by both the drivers tree *and* the current driver and uses the current driver key to make an update (adding updates after an accept was failing).

Also adds them to the "collaborators" list there