### PR TITLE
upgrade wasm-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3591,6 +3591,11 @@
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
     "array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -3766,6 +3771,14 @@
         "num2fraction": "^1.2.2",
         "postcss": "^7.0.27",
         "postcss-value-parser": "^4.0.3"
+      }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
       }
     },
     "aws-sign2": {
@@ -7771,6 +7784,11 @@
         "for-in": "^1.0.1"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -9843,6 +9861,17 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "requires": {
+        "available-typed-arrays": "^1.0.0",
+        "es-abstract": "^1.17.4",
+        "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
       }
     },
@@ -14634,9 +14663,9 @@
       }
     },
     "p-queue": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.3.0.tgz",
-      "integrity": "sha512-fg5dJlFpd5+3CgG3/0ogpVZUeJbjiyXFg0nu53hrOYsybqSiDyxyOpad0Rm6tAiGjgztAwkyvhlYHC53OiAJOA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.4.0.tgz",
+      "integrity": "sha512-X7ddxxiQ+bLR/CUt3/BVKrGcJDNxBr0pEEFKHHB6vTPWNUhgDv36GpIH18RmGM3YGPpBT+JWGjDDqsVGuF0ERw==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "p-timeout": "^3.1.0"
@@ -16251,9 +16280,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
-          "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
+          "version": "13.13.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
+          "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g=="
         }
       }
     },
@@ -19262,9 +19291,9 @@
       "integrity": "sha512-h7VBb4Un8BX9/9bYfyeZcMS1vh+OcqPgGBw4UJsdi0LFc1F5lenTT92MueGuZgBYHNDnUTtxZDToLL3eH05jQA=="
     },
     "tupelo-wasm-sdk": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/tupelo-wasm-sdk/-/tupelo-wasm-sdk-0.7.2.tgz",
-      "integrity": "sha512-60IoBv2ZaRn06tQ3WQu/9k5LPSi9+EZohnLajS9PZFtvXhcKUtfCR1JFwwUIQLafa/HZY8cBODd20kJSnNKh2Q==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/tupelo-wasm-sdk/-/tupelo-wasm-sdk-0.7.3.tgz",
+      "integrity": "sha512-BuOxMEkwvXpRKL15dtSQklGrPnnCNlyTN4zlIbN6iVdrAccIfG2byFtvrySG80iBfqU63KOVPwNnCH4kd89gvA==",
       "requires": {
         "@types/debug": "^4.1.5",
         "@types/detect-node": "^2.0.0",
@@ -19306,14 +19335,16 @@
       },
       "dependencies": {
         "util": {
-          "version": "0.12.2",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.2.tgz",
-          "integrity": "sha512-XE+MkWQvglYa+IOfBt5UFG93EmncEMP23UqpgDvVZVFBPxwmkK10QRp6pgU4xICPnWRf/t0zPv4noYSUq9gqUQ==",
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+          "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
           "requires": {
             "inherits": "^2.0.3",
             "is-arguments": "^1.0.4",
             "is-generator-function": "^1.0.7",
-            "safe-buffer": "^5.1.2"
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
           }
         }
       }
@@ -21386,6 +21417,19 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "which-typed-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "es-abstract": "^1.17.5",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-qrcode-logo": "^2.2.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
-    "tupelo-wasm-sdk": "^0.7.2",
+    "tupelo-wasm-sdk": "^0.7.3",
     "typescript": "^3.7.5",
     "url-parse": "^1.4.7",
     "uuid": "^7.0.2"


### PR DESCRIPTION
In production the bug of local ownership information not-being-available shows up - upgrading the SDK to latest with the bug fix.